### PR TITLE
ref(age): for libraries use Render and Register (#429)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -132,12 +132,12 @@ tasks:
   # task venus -- -filter RETRO-WAVE,DUB
   venus:
     cmds:
-      - go run ./test/cmd/venus/main.go {{.CLI_ARGS}}
+      - go run ./src/agenor/test/cmd/venus/main.go {{.CLI_ARGS}}
 
   # quick venus test
   venus-t:
     cmds:
-      - go run ./test/cmd/venus/main.go -path . -filter RETRO-WAVE,DUB -pattern "*|flac"
+      - go run ./src/agenor/test/cmd/venus/main.go -path . -filter RETRO-WAVE,DUB -pattern "*|flac"
 
   nex:
     cmds:

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/google/pprof v0.0.0-20260302011040-a15ffb7f9dcc // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/pkg/errors v0.9.1
-	github.com/snivilised/li18ngo v0.1.11
+	github.com/snivilised/li18ngo v0.1.12
 	github.com/snivilised/nefilim v0.1.11
 	github.com/snivilised/pants v0.1.5
 	golang.org/x/net v0.52.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/snivilised/li18ngo v0.1.10 h1:l0xiT278GdUjEmGIzUmM/UQ2/zlrVuc0kevmCU3
 github.com/snivilised/li18ngo v0.1.10/go.mod h1:+Oc4DADP9XISZEDZLiiG1WLonZo309Dj4e/zBcsNHNw=
 github.com/snivilised/li18ngo v0.1.11 h1:VA/lWdl1mgcX9GvvEWnHLS5FgPC7POcbiAvylF/NCsI=
 github.com/snivilised/li18ngo v0.1.11/go.mod h1:X3H8jGoVwlasAClPw5P+Qemy1AAl2jq5A+GebkMypPw=
+github.com/snivilised/li18ngo v0.1.12 h1:rwrg0zjylxRJe+plzNu++qwCy5TnoE3CCBouFKqU1fs=
+github.com/snivilised/li18ngo v0.1.12/go.mod h1:X3H8jGoVwlasAClPw5P+Qemy1AAl2jq5A+GebkMypPw=
 github.com/snivilised/mamba v0.1.1 h1:njG8ievm3W7wKoWkj2HbHH6JA4PnklS5DX1l9kWta0A=
 github.com/snivilised/mamba v0.1.1/go.mod h1:Wc2BOpzlkCYkdrRHndZFBgqMr8Cziy3/gTSbZlbk6L0=
 github.com/snivilised/nefilim v0.1.11 h1:i8o4vb/4oNi6GVfTGUdUDqvINn8RyTmLdvVRW/aDu4A=

--- a/src/agenor/composites_test.go
+++ b/src/agenor/composites_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Composites", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/director-error_test.go
+++ b/src/agenor/director-error_test.go
@@ -35,7 +35,7 @@ var _ = Describe("director error", Ordered, func() {
 			return nil
 		}
 
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/director-prime_test.go
+++ b/src/agenor/director-prime_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Director(Prime)", Ordered, func() {
 	// 👽 These tests are not using Nuxx therefore they are traversing the
 	// local test directory.
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/director-resume_test.go
+++ b/src/agenor/director-resume_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Director(Resume)", Ordered, func() {
 		tree = hanno.Repo("test")
 		resumeAt = filepath.Join(tree, "hydra")
 
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/feat/hiber/hibernate-simple-profile.go
+++ b/src/agenor/internal/feat/hiber/hibernate-simple-profile.go
@@ -33,7 +33,7 @@ func (p *simple) init(controls *life.Controls) error {
 		if p.triggers.sleep == nil {
 			p.triggers.sleep = filtering.NewProhibitiveTraverseFilter(
 				&core.FilterDef{
-					Description: li18ngo.Text(locale.ProhibitiveWordTemplData{}),
+					Description: li18ngo.Render(locale.ProhibitiveWordTemplData{}),
 				},
 			)
 		}
@@ -50,7 +50,7 @@ func (p *simple) init(controls *life.Controls) error {
 		if p.triggers.wake == nil {
 			p.triggers.wake = filtering.NewPermissiveTraverseFilter(
 				&core.FilterDef{
-					Description: li18ngo.Text(locale.PermissiveWordTemplData{}),
+					Description: li18ngo.Render(locale.PermissiveWordTemplData{}),
 				},
 			)
 		}

--- a/src/agenor/internal/feat/hiber/hibernate_test.go
+++ b/src/agenor/internal/feat/hiber/hibernate_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
 	lab "github.com/snivilised/jaywalk/src/agenor/internal/laboratory"
-	"github.com/snivilised/jaywalk/src/internal/services"
-	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/agenor/test/hanno"
 	"github.com/snivilised/jaywalk/src/agenor/tfs"
+	"github.com/snivilised/jaywalk/src/internal/services"
+	"github.com/snivilised/jaywalk/src/internal/third/lo"
 )
 
 var _ = Describe("feature", Ordered, func() {
@@ -39,7 +39,7 @@ var _ = Describe("feature", Ordered, func() {
 		fS, err = hanno.CustomTree(index, "MUSICO", verbose, lab.Static.RetroWave, "edm")
 
 		Expect(err).To(Succeed(), "Failed to initialise custom tree with MUSICO data")
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/feat/hiber/with-filter_test.go
+++ b/src/agenor/internal/feat/hiber/with-filter_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
 	lab "github.com/snivilised/jaywalk/src/agenor/internal/laboratory"
-	"github.com/snivilised/jaywalk/src/internal/services"
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/agenor/test/hanno"
 	"github.com/snivilised/jaywalk/src/agenor/tfs"
+	"github.com/snivilised/jaywalk/src/internal/services"
 )
 
 var _ = Describe("feature", Ordered, func() {
@@ -29,7 +29,7 @@ var _ = Describe("feature", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, lab.Static.RetroWave, "edm")
 
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/feat/resume/resume-error_test.go
+++ b/src/agenor/internal/feat/resume/resume-error_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Resume Error", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/feat/resume/resume-local-fs_test.go
+++ b/src/agenor/internal/feat/resume/resume-local-fs_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Resume local-fs", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/feat/resume/resume_test.go
+++ b/src/agenor/internal/feat/resume/resume_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Resume", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/feat/resume/save_test.go
+++ b/src/agenor/internal/feat/resume/save_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Save", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/feat/sampling/navigator-sample_test.go
+++ b/src/agenor/internal/feat/sampling/navigator-sample_test.go
@@ -32,7 +32,7 @@ var _ = Describe("feature", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, lab.Static.RetroWave, "edm")
 
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/filtering/filter-custom_test.go
+++ b/src/agenor/internal/filtering/filter-custom_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
 	lab "github.com/snivilised/jaywalk/src/agenor/internal/laboratory"
-	"github.com/snivilised/jaywalk/src/internal/services"
-	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/agenor/test/hanno"
 	"github.com/snivilised/jaywalk/src/agenor/tfs"
+	"github.com/snivilised/jaywalk/src/internal/services"
+	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/li18ngo"
 	"github.com/snivilised/nefilim/test/luna"
 )
@@ -29,7 +29,7 @@ var _ = Describe("NavigatorFilterCustom", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, lab.Static.RetroWave)
 
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/filtering/filter-errata_test.go
+++ b/src/agenor/internal/filtering/filter-errata_test.go
@@ -29,7 +29,7 @@ var _ = Describe("NavigatorFilterCustom", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, lab.Static.RetroWave)
 
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/filtering/filter-glob-ex_test.go
+++ b/src/agenor/internal/filtering/filter-glob-ex_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
 	lab "github.com/snivilised/jaywalk/src/agenor/internal/laboratory"
-	"github.com/snivilised/jaywalk/src/internal/services"
-	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/agenor/test/hanno"
 	"github.com/snivilised/jaywalk/src/agenor/tfs"
+	"github.com/snivilised/jaywalk/src/internal/services"
+	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/li18ngo"
 	"github.com/snivilised/nefilim/test/luna"
 )
@@ -29,7 +29,7 @@ var _ = Describe("filtering", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, "rock")
 
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/filtering/filter-glob_test.go
+++ b/src/agenor/internal/filtering/filter-glob_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
 	lab "github.com/snivilised/jaywalk/src/agenor/internal/laboratory"
-	"github.com/snivilised/jaywalk/src/internal/services"
-	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/agenor/test/hanno"
 	"github.com/snivilised/jaywalk/src/agenor/tfs"
+	"github.com/snivilised/jaywalk/src/internal/services"
+	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/li18ngo"
 	"github.com/snivilised/nefilim/test/luna"
 )
@@ -29,7 +29,7 @@ var _ = Describe("NavigatorFilterGlob", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, lab.Static.RetroWave)
 
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/filtering/filter-hybrid_test.go
+++ b/src/agenor/internal/filtering/filter-hybrid_test.go
@@ -29,7 +29,7 @@ var _ = Describe("feature", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, lab.Static.RetroWave)
 
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/filtering/filter-poly_test.go
+++ b/src/agenor/internal/filtering/filter-poly_test.go
@@ -32,7 +32,7 @@ var _ = Describe("feature", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, lab.Static.RetroWave)
 
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/filtering/filter-regex_test.go
+++ b/src/agenor/internal/filtering/filter-regex_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
 	lab "github.com/snivilised/jaywalk/src/agenor/internal/laboratory"
-	"github.com/snivilised/jaywalk/src/internal/services"
-	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/agenor/test/hanno"
 	"github.com/snivilised/jaywalk/src/agenor/tfs"
+	"github.com/snivilised/jaywalk/src/internal/services"
+	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/li18ngo"
 	"github.com/snivilised/nefilim/test/luna"
 )
@@ -33,7 +33,7 @@ var _ = Describe("feature", Ordered, func() {
 			lab.Static.RetroWave, "PROGRESSIVE-HOUSE",
 		)
 
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/filtering/glob-spec_test.go
+++ b/src/agenor/internal/filtering/glob-spec_test.go
@@ -39,7 +39,7 @@ var _ = Describe("GlobSpec", Ordered, func() {
 	var re *regexp.Regexp
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 
 		re = regexp.MustCompile(GlobExPattern)
 	})

--- a/src/agenor/internal/kernel/navigator-async_test.go
+++ b/src/agenor/internal/kernel/navigator-async_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Navigator", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/kernel/navigator-cascade_test.go
+++ b/src/agenor/internal/kernel/navigator-cascade_test.go
@@ -26,7 +26,7 @@ var _ = Describe("navigator", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/kernel/navigator-directories-with-files_test.go
+++ b/src/agenor/internal/kernel/navigator-directories-with-files_test.go
@@ -29,7 +29,7 @@ var _ = Describe("NavigatorDirectoriesWithFiles", Ordered, func() {
 
 		fS = hanno.Nuxx(verbose, lab.Static.RetroWave)
 
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/kernel/navigator-files_test.go
+++ b/src/agenor/internal/kernel/navigator-files_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("NavigatorFiles", Ordered, func() {
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/kernel/navigator-vanilla_test.go
+++ b/src/agenor/internal/kernel/navigator-vanilla_test.go
@@ -35,7 +35,7 @@ var _ = Describe("NavigatorUniversal", Ordered, func() {
 			filepath.Join("rock", "metal"),
 		)
 
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/agenor/internal/persist/convert-json_test.go
+++ b/src/agenor/internal/persist/convert-json_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Convert Options via JSON", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	BeforeEach(func() {

--- a/src/agenor/internal/persist/marshaler-filters_test.go
+++ b/src/agenor/internal/persist/marshaler-filters_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Marshaler", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 
 		readPath = source + "/" + restoreFile
 	})

--- a/src/agenor/internal/persist/marshaler-local-fs_test.go
+++ b/src/agenor/internal/persist/marshaler-local-fs_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Marshaler", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 
 		testPath = hanno.Repo("test")
 		testFile := filepath.Join(testPath, destination, tempFile)

--- a/src/agenor/internal/persist/marshaler_test.go
+++ b/src/agenor/internal/persist/marshaler_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Marshaler", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 
 		readPath = source + "/" + restoreFile
 	})

--- a/src/agenor/life/events_test.go
+++ b/src/agenor/life/events_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("controls", Ordered, func() {
 	BeforeAll(func() {
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	When("bind", func() {

--- a/src/agenor/pref/with-operators_test.go
+++ b/src/agenor/pref/with-operators_test.go
@@ -28,7 +28,7 @@ var (
 
 var _ = Describe("With Operators", Ordered, func() {
 	BeforeAll(func() {
-		Expect(li18ngo.Use()).To(Succeed())
+		Expect(li18ngo.Register()).To(Succeed())
 	})
 
 	Context("WithCPU", func() {

--- a/src/agenor/test/cmd/venus/main.go
+++ b/src/agenor/test/cmd/venus/main.go
@@ -20,10 +20,10 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
 	lab "github.com/snivilised/jaywalk/src/agenor/internal/laboratory"
-	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/agenor/test/hanno"
 	"github.com/snivilised/jaywalk/src/agenor/tfs"
+	"github.com/snivilised/jaywalk/src/internal/third/lo"
 	"github.com/snivilised/li18ngo"
 )
 
@@ -52,6 +52,8 @@ type navigation struct {
 
 func main() {
 	var filters multiFlag
+
+	_ = li18ngo.Register()
 
 	path := flag.String("path", "",
 		"path to navigate from",

--- a/src/app/command/bootstrap.go
+++ b/src/app/command/bootstrap.go
@@ -226,7 +226,7 @@ func handleLangSetting() {
 		},
 	)
 
-	err := li18ngo.Use(func(uo *li18ngo.UseOptions) {
+	err := li18ngo.Register(func(uo *li18ngo.UseOptions) {
 		uo.Tag = tag
 		uo.From = li18ngo.LoadFrom{
 			Sources: li18ngo.TranslationFiles{

--- a/src/app/ui/manager_test.go
+++ b/src/app/ui/manager_test.go
@@ -19,7 +19,7 @@ import (
 
 var _ = Describe("ui.New", Ordered, func() {
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},
@@ -87,7 +87,7 @@ var _ = Describe("linear Manager", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Expect(li18ngo.Use(
+		Expect(li18ngo.Register(
 			func(o *li18ngo.UseOptions) {
 				o.From.Sources = li18ngo.TranslationFiles{
 					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},

--- a/src/locale/messages-errors_test.go
+++ b/src/locale/messages-errors_test.go
@@ -34,7 +34,7 @@ var _ = Describe("error messages", Ordered, func() {
 	})
 
 	BeforeEach(func() {
-		if err := li18ngo.Use(func(o *li18ngo.UseOptions) {
+		if err := li18ngo.Register(func(o *li18ngo.UseOptions) {
 			o.Tag = li18ngo.DefaultLanguage
 			o.From.Sources = testTranslationFile
 		}); err != nil {


### PR DESCRIPTION
ref(age): replace Use with Register (#429)

ref(age): replace Text with Render (#429)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated i18n dependency to the latest version for improved localization support.
  * Refactored internal initialization patterns for i18n configuration across test suites and application bootstrap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->