### PR TITLE
ref: rename run command to sprint (#469)

### DIFF
--- a/src/agenor/builders.go
+++ b/src/agenor/builders.go
@@ -18,7 +18,7 @@ type buildArtefacts struct {
 
 // Builders performs build orchestration via its buildAll method. Builders
 // is instructed by the factories (via Configure) of which there are 2; one
-// for Walk and one for Run. The Prime/Resume extents create the Builders
+// for Walk and one for Sprint. The Prime/Resume extents create the Builders
 // instance.
 type Builders struct {
 	facade    pref.Facade

--- a/src/agenor/composites.go
+++ b/src/agenor/composites.go
@@ -10,19 +10,19 @@ import (
 // that would otherwise require code duplication.
 //
 // 🐍 `Hydra` (multi faceted/many headed) : supports all four scenarios
-// 🐰 `Hare` (speedy): only supports run
+// 🐰 `Hare` (speedy): only supports sprint
 // 🐢 `Tortoise` (slow): only supports walk
 // 🐡 `Goldfish` (no memory/no resume) : only supports prime
 
 type (
-	// Scenario is a function that encodes within it the semantics of walk vs run
+	// Scenario is a function that encodes within it the semantics of walk vs sprint
 	// and prime vs resume. When invoked, it returns the underlying navigator
 	// upon which a traversal session can be executed. The defined scenarios are
 	// as follows:
 	// * walk/prime
 	// * walk/resume
-	// * run/prime
-	// * run/resume
+	// * sprint/prime
+	// * sprint/resume
 	Scenario func(facade pref.Facade, settings ...pref.Option) Navigator
 )
 
@@ -43,19 +43,19 @@ type (
 //
 // agenor.Walk().Configure().Extent(agenor.Resume(facade, options...)).Navigate(ctx)
 //
-// The run scenarios would ordinarily look something like this...
+// The sprint scenarios would ordinarily look something like this...
 //
-// # Run/Prime
-//
-// Example:
-//
-// agenor.Run().Configure().Extent(agenor.Prime(facade, options...)).Navigate(ctx)
-//
-// # Run/Resume
+// # Sprint/Prime
 //
 // Example:
 //
-// agenor.Run().Configure().Extent(agenor.Resume(facade, options...)).Navigate(ctx)
+// agenor.Sprint().Configure().Extent(agenor.Prime(facade, options...)).Navigate(ctx)
+//
+// # Sprint/Resume
+//
+// Example:
+//
+// agenor.Sprint().Configure().Extent(agenor.Resume(facade, options...)).Navigate(ctx)
 //
 // and these would need to be invoked conditionally depending on flags on the CLI.
 // Notice the duplication; this can be resolved using the Hydra composite
@@ -67,7 +67,7 @@ type (
 // Example:
 //
 //	var wg sync.WaitGroup
-//	isWalk := \<set depending on wether user requested walk or run\>
+//	isWalk := \<set depending on wether user requested walk or sprint\>
 //	isPrime := \<set depending on wether user requested prime or resume\>
 //	agenor.Hydra(isWalk, isPrime, &wg)(facade, options...).Navigate(ctx)
 func Hydra(isWalk, isPrime bool, wg pants.WaitGroup) Scenario {
@@ -91,25 +91,25 @@ func Hydra(isWalk, isPrime bool, wg pants.WaitGroup) Scenario {
 }
 
 // Hare is a composite that a client can use to build a cli that only implements
-// the run scenarios.
+// the sprint scenarios.
 //
-// The run scenarios would ordinarily look something like this...
+// The sprint scenarios would ordinarily look something like this...
 //
-// # Run/Prime
-//
-// Example:
-//
-// agenor.Run().Configure().Extent(agenor.Prime(facade, options...)).Navigate(ctx)
-//
-// # Run/Resume
+// # Sprint/Prime
 //
 // Example:
 //
-// agenor.Run().Configure().Extent(agenor.Resume(facade, options...)).Navigate(ctx)
+// agenor.Sprint().Configure().Extent(agenor.Prime(facade, options...)).Navigate(ctx)
+//
+// # Sprint/Resume
+//
+// Example:
+//
+// agenor.Sprint().Configure().Extent(agenor.Resume(facade, options...)).Navigate(ctx)
 //
 // and these would need to be invoked conditionally depending on flags on the CLI.
 // Notice the duplication; this can be resolved using the Hare composite
-// which can only invoke Run sessions, so the query function is being asked to
+// which can only invoke Sprint sessions, so the query function is being asked to
 // determine if it should prime or resume:
 //
 // # Hare
@@ -179,23 +179,23 @@ func Tortoise(isPrime bool) Scenario {
 //
 // agenor.Walk().Configure().Extent(agenor.Prime(facade, options...)).Navigate(ctx)
 //
-// # Run/Prime
+// # Sprint/Prime
 //
 // Example:
 //
-// agenor.Run().Configure().Extent(agenor.Prime(facade, options...)).Navigate(ctx)
+// agenor.Sprint().Configure().Extent(agenor.Prime(facade, options...)).Navigate(ctx)
 //
 // and these would need to be invoked conditionally depending on flags on the CLI.
 // Notice the duplication; this can be resolved using the Goldfish composite
 // which can only run Prime sessions, so the query function is being asked to
-// determine if it should walk or run:
+// determine if it should walk or sprint:
 //
 // # Goldfish
 //
 // Example:
 //
 //	var wg sync.WaitGroup
-//	isWalk := \<set depending on wether user requested walk or run\>
+//	isWalk := \<set depending on wether user requested walk or sprint\>
 //	agenor.Goldfish(isWalk, &wg)(facade, options...).Navigate(ctx)
 func Goldfish(isWalk bool, wg pants.WaitGroup) Scenario {
 	if isWalk {
@@ -222,14 +222,14 @@ func SlowResume(facade pref.Facade, settings ...pref.Option) Navigator {
 }
 
 func FastPrime(facade pref.Facade, wg pants.WaitGroup, settings ...pref.Option) Navigator {
-	return Run(wg).Configure().Extent(Prime(
+	return Sprint(wg).Configure().Extent(Prime(
 		facade,
 		settings...,
 	))
 }
 
 func FastResume(facade pref.Facade, wg pants.WaitGroup, settings ...pref.Option) Navigator {
-	return Run(wg).Configure().Extent(Resume(
+	return Sprint(wg).Configure().Extent(Resume(
 		facade,
 		settings...,
 	))

--- a/src/agenor/composites_test.go
+++ b/src/agenor/composites_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Composites", Ordered, func() {
 		}),
 		Entry(nil, &lab.CompositeTE{
 			AsyncTE: lab.AsyncTE{
-				Given:  "is run/prime",
+				Given:  "is sprint/prime",
 				Should: "return prime extent with concurrent sync",
 			},
 			IsWalk:  false,
@@ -109,7 +109,7 @@ var _ = Describe("Composites", Ordered, func() {
 		}),
 		Entry(nil, &lab.CompositeTE{
 			AsyncTE: lab.AsyncTE{
-				Given:  "is run/resume",
+				Given:  "is sprint/resume",
 				Should: "return resume extent with concurrent sync",
 			},
 			IsWalk:  false,
@@ -189,7 +189,7 @@ var _ = Describe("Composites", Ordered, func() {
 		}),
 		Entry(nil, &lab.CompositeTE{
 			AsyncTE: lab.AsyncTE{
-				Given:  "is run",
+				Given:  "is sprint",
 				Should: "return prime extent with concurrent sync",
 			},
 			IsWalk: false,

--- a/src/agenor/director-error_test.go
+++ b/src/agenor/director-error_test.go
@@ -186,7 +186,7 @@ var _ = Describe("director error", Ordered, func() {
 			lab.WithTestContext(specCtx, func(ctx context.Context, _ context.CancelFunc) {
 				var wg sync.WaitGroup
 
-				_, err := agenor.Run(&wg).Configure().Extent(agenor.Prime(
+				_, err := agenor.Sprint(&wg).Configure().Extent(agenor.Prime(
 					&pref.Using{
 						Head: pref.Head{
 							Handler: noOpHandler,

--- a/src/agenor/director-prime_test.go
+++ b/src/agenor/director-prime_test.go
@@ -90,9 +90,9 @@ var _ = Describe("Director(Prime)", Ordered, func() {
 			})
 		})
 
-		Context("Run", func() {
+		Context("Sprint", func() {
 			When("Options", func() {
-				It("🧪 should: perform run navigation successfully", func(specCtx SpecContext) {
+				It("🧪 should: perform sprint navigation successfully", func(specCtx SpecContext) {
 					lab.WithTestContext(specCtx, func(ctx context.Context, _ context.CancelFunc) {
 						var wg sync.WaitGroup
 
@@ -107,7 +107,7 @@ var _ = Describe("Director(Prime)", Ordered, func() {
 						// can we tap into cancellation?
 						//
 
-						_, err := agenor.Run(&wg).Configure().Extent(agenor.Prime(
+						_, err := agenor.Sprint(&wg).Configure().Extent(agenor.Prime(
 							&pref.Using{
 								Subscription: agenor.SubscribeFiles,
 								Head: pref.Head{
@@ -133,7 +133,7 @@ var _ = Describe("Director(Prime)", Ordered, func() {
 
 						o, _, _ := opts.Get()
 						o.Defects.Fault = agenor.Accepter(lab.IgnoreFault)
-						_, err := agenor.Run(&wg).Configure().Extent(agenor.Prime(
+						_, err := agenor.Sprint(&wg).Configure().Extent(agenor.Prime(
 							&pref.Using{
 								Subscription: agenor.SubscribeFiles,
 								Head: pref.Head{

--- a/src/agenor/director-resume_test.go
+++ b/src/agenor/director-resume_test.go
@@ -97,12 +97,12 @@ var _ = Describe("Director(Resume)", Ordered, func() {
 			})
 		})
 
-		Context("Run", func() {
+		Context("Sprint", func() {
 			XIt("🧪 should: perform run navigation successfully", func(specCtx SpecContext) {
 				lab.WithTestContext(specCtx, func(ctx context.Context, _ context.CancelFunc) {
 					var wg sync.WaitGroup
 
-					_, err := agenor.Run(&wg).Configure(enclave.Loader(func(active *core.ActiveState) {
+					_, err := agenor.Sprint(&wg).Configure(enclave.Loader(func(active *core.ActiveState) {
 						active.Tree = tree
 						active.Depth = 2
 						active.TraverseDescription.IsRelative = true
@@ -135,13 +135,13 @@ var _ = Describe("Director(Resume)", Ordered, func() {
 	})
 
 	Context("features", func() {
-		Context("Run", func() {
+		Context("Sprint", func() {
 			When("filter", func() {
 				It("🧪 should: register ok", func(specCtx SpecContext) {
 					lab.WithTestContext(specCtx, func(ctx context.Context, _ context.CancelFunc) {
 						var wg sync.WaitGroup
 
-						_, err := agenor.Run(&wg).Configure().Extent(agenor.Resume(
+						_, err := agenor.Sprint(&wg).Configure().Extent(agenor.Resume(
 							&pref.Relic{
 								Head: pref.Head{
 									Handler: noOpHandler,
@@ -165,7 +165,7 @@ var _ = Describe("Director(Resume)", Ordered, func() {
 					lab.WithTestContext(specCtx, func(ctx context.Context, _ context.CancelFunc) {
 						var wg sync.WaitGroup
 
-						_, err := agenor.Run(&wg).Configure().Extent(agenor.Resume(
+						_, err := agenor.Sprint(&wg).Configure().Extent(agenor.Resume(
 							&pref.Relic{
 								Head: pref.Head{
 									Handler: noOpHandler,
@@ -193,7 +193,7 @@ var _ = Describe("Director(Resume)", Ordered, func() {
 					lab.WithTestContext(specCtx, func(ctx context.Context, _ context.CancelFunc) {
 						var wg sync.WaitGroup
 
-						_, err := agenor.Run(&wg).Configure().Extent(agenor.Resume(
+						_, err := agenor.Sprint(&wg).Configure().Extent(agenor.Resume(
 							&pref.Relic{
 								Head: pref.Head{
 									Handler: noOpHandler,

--- a/src/agenor/factories.go
+++ b/src/agenor/factories.go
@@ -9,8 +9,8 @@ func Walk() NavigatorFactory {
 	return &walkerFac{}
 }
 
-// Run requests a concurrent traversal of a directory tree.
-func Run(wg pants.WaitGroup) NavigatorFactory {
+// Sprint requests a concurrent traversal of a directory tree.
+func Sprint(wg pants.WaitGroup) NavigatorFactory {
 	return &runnerFac{
 		wg: wg,
 	}

--- a/src/agenor/internal/feat/resume/save_test.go
+++ b/src/agenor/internal/feat/resume/save_test.go
@@ -184,5 +184,5 @@ var _ = Describe("Save", Ordered, func() {
 			})
 		})
 	})
-	// TODO: repeat for concurrent sync (agenor.Run).
+	// TODO: repeat for concurrent sync (agenor.Sprint).
 })

--- a/src/agenor/internal/kernel/navigator-async_test.go
+++ b/src/agenor/internal/kernel/navigator-async_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Navigator", Ordered, func() {
 		services.Reset()
 	})
 
-	DescribeTable("run",
+	DescribeTable("sprint",
 		func(specCtx SpecContext, entry *lab.AsyncOkTE) {
 			lab.WithTestContext(specCtx, func(ctx context.Context, _ context.CancelFunc) {
 				var (
@@ -160,7 +160,7 @@ var _ = Describe("Navigator", Ordered, func() {
 					}
 				}
 
-				result, err := agenor.Run(&wg).Configure(enclave.Loader(func(active *core.ActiveState) {
+				result, err := agenor.Sprint(&wg).Configure(enclave.Loader(func(active *core.ActiveState) {
 					GinkgoWriter.Printf("===> 🐚 restoring state: resume at=%v, subscription=%v\n",
 						entry.Resume.At, entry.Subscription,
 					)
@@ -195,7 +195,7 @@ var _ = Describe("Navigator", Ordered, func() {
 		Entry(nil, &lab.AsyncOkTE{
 			AsyncTE: lab.AsyncTE{
 				Given:        "Primary Session WithCPUPool",
-				Should:       "run with context",
+				Should:       "sprint with context",
 				Callback:     AsyncNoWCallback("PRIME", 0),
 				Builder:      PrimeBuilder,
 				Path:         func() string { return lab.Static.RetroWave },
@@ -207,7 +207,7 @@ var _ = Describe("Navigator", Ordered, func() {
 		Entry(nil, &lab.AsyncOkTE{
 			AsyncTE: lab.AsyncTE{
 				Given:        "Primary Session NoW=3",
-				Should:       "run with context",
+				Should:       "sprint with context",
 				Callback:     AsyncNoWCallback("PRIME", 3),
 				Builder:      PrimeBuilder,
 				Path:         func() string { return lab.Static.RetroWave },
@@ -219,7 +219,7 @@ var _ = Describe("Navigator", Ordered, func() {
 		Entry(nil, &lab.AsyncOkTE{
 			AsyncTE: lab.AsyncTE{
 				Given:        "Resume Session NoW=3",
-				Should:       "run with context",
+				Should:       "sprint with context",
 				Callback:     AsyncNoWCallback("RESUME", 3),
 				Builder:      ResumeBuilder,
 				Path:         func() string { return from },

--- a/src/agenor/internal/opts/jason/concurrency-options.go
+++ b/src/agenor/internal/opts/jason/concurrency-options.go
@@ -5,7 +5,7 @@ type (
 	ConcurrencyOptions struct {
 		// NoW specifies the number of go-routines to use in the worker
 		// pool used for concurrent traversal sessions requested by using
-		// the Run function.
+		// the Sprint function.
 		NoW uint `json:"no-of-workers"`
 	}
 )

--- a/src/agenor/pref/options-concurrency.go
+++ b/src/agenor/pref/options-concurrency.go
@@ -52,7 +52,7 @@ type (
 	ConcurrencyOptions struct {
 		// NoW specifies the number of go-routines to use in the worker
 		// pool used for concurrent traversal sessions requested by using
-		// the Run function.
+		// the Sprint function.
 		NoW uint
 
 		// Input contains input channel properties
@@ -64,7 +64,7 @@ type (
 )
 
 // WithCPU configures the worker pool used for concurrent traversal sessions
-// in the Run function to utilise a number of go-routines equal to the available
+// in the Sprint function to utilise a number of go-routines equal to the available
 // CPU count, optimising performance based on the system's processing capabilities.
 func WithCPU() Option {
 	return func(o *Options) error {
@@ -76,7 +76,7 @@ func WithCPU() Option {
 
 // WithNoW sets the number of go-routines to use in the worker
 // pool used for concurrent traversal sessions requested by using
-// the Run function.
+// the Sprint function.
 func WithNoW(now uint) Option {
 	return func(o *Options) error {
 		o.Concurrency.NoW = now

--- a/src/agenor/traverse-api.go
+++ b/src/agenor/traverse-api.go
@@ -239,7 +239,7 @@ var (
 	WithAdminPath = pref.WithAdminPath
 
 	// WithCPU configures the worker pool used for concurrent traversal sessions
-	// in the Run function to utilise a number of go-routines equal to the available
+	// in the Sprint function to utilise a number of go-routines equal to the available
 	// CPU count, optimising performance based on the system's processing capabilities.
 	WithCPU = pref.WithCPU
 
@@ -348,7 +348,7 @@ var (
 
 	// WithNoW sets the number of go-routines to use in the worker
 	// pool used for concurrent traversal sessions requested by using
-	// the Run function.
+	// the Sprint function.
 	WithNoW = pref.WithNoW
 
 	// WithSamplingOptions specifies the sampling options.

--- a/src/app/bedrock/example-config.yml
+++ b/src/app/bedrock/example-config.yml
@@ -45,7 +45,7 @@ flags:
       cmds:
         walk:
           foo: F
-        run:
+        sprint:
           bar: Z
   # invoke defines defaults for flags not specified on the command line. Flags
   # defined here, override any that may be defined at the component level.

--- a/src/app/bedrock/fixtures_test.go
+++ b/src/app/bedrock/fixtures_test.go
@@ -33,7 +33,7 @@ flags:
       cmds:
         walk:
           foo: F
-        run:
+        sprint:
           bar: Z
   invoke:
     cmds:

--- a/src/app/bedrock/flags_test.go
+++ b/src/app/bedrock/flags_test.go
@@ -89,7 +89,7 @@ var _ = Describe("FlagResolver", Ordered, func() {
 
 			Context("and no invoke default exists but a component default does", func() {
 				It("uses the component default", func() {
-					// No invoke entry for "run"
+					// No invoke entry for "sprint"
 					flags2 := bedrock.FlagsConfig{
 						Invoke: bedrock.FlagInvokeDefaults{},
 						Component: bedrock.FlagComponentDefaults{
@@ -97,7 +97,7 @@ var _ = Describe("FlagResolver", Ordered, func() {
 						},
 					}
 					r2 := bedrock.NewFlagResolver(flags2)
-					cmd := newCmd("run", map[string]int{"files": 1})
+					cmd := newCmd("sprint", map[string]int{"files": 1})
 
 					val, ok := r2.ResolveInt(cmd, "files", "sampler")
 					Expect(ok).To(BeTrue())
@@ -108,7 +108,7 @@ var _ = Describe("FlagResolver", Ordered, func() {
 			Context("and no config defaults exist at all", func() {
 				It("falls back to the cobra default", func() {
 					r2 := bedrock.NewFlagResolver(bedrock.FlagsConfig{})
-					cmd := newCmd("run", map[string]int{"files": 42})
+					cmd := newCmd("sprint", map[string]int{"files": 42})
 
 					val, ok := r2.ResolveInt(cmd, "files", "")
 					Expect(ok).To(BeTrue())
@@ -145,7 +145,7 @@ var _ = Describe("FlagResolver", Ordered, func() {
 			}
 			resolver := bedrock.NewFlagResolver(flags)
 
-			cmd := &cobra.Command{Use: "run"}
+			cmd := &cobra.Command{Use: "sprint"}
 			cmd.Flags().StringP("foo", "f", "", "a flag")
 
 			resolver.ApplyShortOverrides(cmd)

--- a/src/app/bedrock/loader_test.go
+++ b/src/app/bedrock/loader_test.go
@@ -123,8 +123,8 @@ var _ = Describe("Load", Ordered, func() {
 			It("contains short override for walk.foo", func() {
 				Expect(config.Raw.Flags.Short["walk"]["foo"]).To(Equal("F"))
 			})
-			It("contains short override for run.bar", func() {
-				Expect(config.Raw.Flags.Short["run"]["bar"]).To(Equal("Z"))
+			It("contains short override for sprint.bar", func() {
+				Expect(config.Raw.Flags.Short["sprint"]["bar"]).To(Equal("Z"))
 			})
 			It("contains invoke.any.files default", func() {
 				val, ok := config.Raw.Flags.Invoke["any"]["files"]

--- a/src/app/command/bootstrap.go
+++ b/src/app/command/bootstrap.go
@@ -85,7 +85,7 @@ type ConfigureOptionFn func(*ConfigureOptions)
 //	  │  exec (ghost)        (exec persistent flags: --resume
 //	  │  │                    + MarkFlagsOneRequired("action", "pipeline"))
 //	  │  │  walk
-//	  │  │  run
+//	  │  │  sprint
 //	  │  query
 //	  verify
 //	  theme
@@ -116,17 +116,17 @@ type Bootstrap struct {
 	// root param-set
 	rootPs *assist.ParamSet[RootParameterSet]
 
-	// nav ghost param-set and persistent families, inherited by walk, run, and query.
+	// nav ghost param-set and persistent families, inherited by walk, sprint, and query.
 	navPs       *assist.ParamSet[NavParameterSet]
 	previewFam  *assist.ParamSet[store.PreviewParameterSet]
 	cascadeFam  *assist.ParamSet[store.CascadeParameterSet]
 	samplingFam *assist.ParamSet[store.SamplingParameterSet]
 	polyFam     *assist.ParamSet[store.PolyFilterParameterSet]
 
-	// exec ghost param-set, inherited by walk and run only.
+	// exec ghost param-set, inherited by walk and sprint only.
 	execPs *assist.ParamSet[ExecParameterSet]
 
-	// run-exclusive family
+	// sprint-exclusive family
 	workerPoolFam *assist.ParamSet[store.WorkerPoolParameterSet]
 }
 
@@ -207,7 +207,7 @@ func (b *Bootstrap) Root(options ...ConfigureOptionFn) *cobra.Command {
 	b.buildNavCommand(b.container)
 	b.buildExecCommand(b.container)
 	b.buildWalkCommand(b.container)
-	b.buildRunCommand(b.container)
+	b.buildSprintCommand(b.container)
 	b.buildQueryCommand(b.container)
 
 	return b.container.Root()
@@ -317,7 +317,7 @@ func (b *Bootstrap) buildRootCommand(container *assist.CobraContainer) {
 // navFamilies
 // ---------------------------------------------------------------------------
 
-// navFamilies is a convenience accessor used by runWalk, runRun, and
+// navFamilies is a convenience accessor used by runWalk, runSprint, and
 // runQuery to obtain the nav-level flag families in a single bundle.
 func (b *Bootstrap) navFamilies() NavFamilies {
 	return NavFamilies{

--- a/src/app/command/bootstrap_test.go
+++ b/src/app/command/bootstrap_test.go
@@ -93,11 +93,11 @@ var _ = Describe("Bootstrap", Ordered, func() {
 				Expect(walkCmd.Flags().Lookup("subscribe")).NotTo(BeNil())
 			})
 
-			It("🧪 should: expose --subscribe on run", func() {
-				runCmd, _, err := buildRoot().Find([]string{"nav", "exec", "run"})
+			It("🧪 should: expose --subscribe on sprint", func() {
+				sprintCmd, _, err := buildRoot().Find([]string{"nav", "exec", "sprint"})
 				Expect(err).To(BeNil())
-				runCmd.InheritedFlags()
-				Expect(runCmd.Flags().Lookup("subscribe")).NotTo(BeNil())
+				sprintCmd.InheritedFlags()
+				Expect(sprintCmd.Flags().Lookup("subscribe")).NotTo(BeNil())
 			})
 
 			It("🧪 should: expose --subscribe on query", func() {
@@ -137,11 +137,11 @@ var _ = Describe("Bootstrap", Ordered, func() {
 				Expect(walkCmd.Flags().Lookup("resume")).NotTo(BeNil())
 			})
 
-			It("🧪 should: expose --resume on run", func() {
-				runCmd, _, err := buildRoot().Find([]string{"nav", "exec", "run"})
+			It("🧪 should: expose --resume on sprint", func() {
+				sprintCmd, _, err := buildRoot().Find([]string{"nav", "exec", "sprint"})
 				Expect(err).To(BeNil())
-				runCmd.InheritedFlags()
-				Expect(runCmd.Flags().Lookup("resume")).NotTo(BeNil())
+				sprintCmd.InheritedFlags()
+				Expect(sprintCmd.Flags().Lookup("resume")).NotTo(BeNil())
 			})
 
 			It("🧪 should: not expose --resume on query", func() {
@@ -176,11 +176,11 @@ var _ = Describe("Bootstrap", Ordered, func() {
 			})
 		})
 
-		Context("worker-pool flags - run exclusive", func() {
-			It("🧪 should: expose --cpu as a local flag on run", func() {
-				runCmd, _, err := buildRoot().Find([]string{"nav", "exec", "run"})
+		Context("worker-pool flags - sprint exclusive", func() {
+			It("🧪 should: expose --cpu as a local flag on sprint", func() {
+				sprintCmd, _, err := buildRoot().Find([]string{"nav", "exec", "sprint"})
 				Expect(err).To(BeNil())
-				Expect(runCmd.Flags().Lookup("cpu")).NotTo(BeNil())
+				Expect(sprintCmd.Flags().Lookup("cpu")).NotTo(BeNil())
 			})
 
 			It("🧪 should: not expose --cpu on walk", func() {

--- a/src/app/command/const.go
+++ b/src/app/command/const.go
@@ -24,22 +24,22 @@ const (
 	// exec ghost command param-set
 	ExecPsName = "exec-ps"
 
-	// shared families (registered on nav ghost, inherited by walk/run/query)
+	// shared families (registered on nav ghost, inherited by walk/sprint/query)
 	PreviewFamName     = "preview-fam"
 	CascadeFamName     = "cascade-fam"
 	InteractionFamName = "interaction-fam"
 	SamplingFamName    = "sampling-fam"
 
-	// poly-filter family (registered on nav ghost, inherited by walk/run/query)
+	// poly-filter family (registered on nav ghost, inherited by walk/sprint/query)
 	PolyFamName = "poly-fam"
 
-	// run-only family
+	// sprint-only family
 	WorkerPoolFamName = "worker-pool-fam"
 
 	// jay-specific param sets
-	WalkPsName  = "walk-ps"
-	RunPsName   = "run-ps"
-	QueryPsName = "query-ps"
+	WalkPsName   = "walk-ps"
+	SprintPsName = "sprint-ps"
+	QueryPsName  = "query-ps"
 )
 
 // ---------------------------------------------------------------------------

--- a/src/app/command/doc.go
+++ b/src/app/command/doc.go
@@ -40,7 +40,7 @@ package command
 // │   │   ├── walk
 // │   │   │     LocalFlags: (none)
 // │   │   │
-// │   │   └── run
+// │   │   └── sprint
 // │   │         LocalFlags:
 // │   │           [worker-pool family]
 // │   │             --cpu

--- a/src/app/command/exec-cmd.go
+++ b/src/app/command/exec-cmd.go
@@ -16,19 +16,19 @@ const (
 
 // buildExecCommand constructs the ghost exec command. It is never intended
 // to be invoked directly by the user - its sole purpose is to own the
-// persistent flags that apply only to execution commands (walk, run) and
+// persistent flags that apply only to execution commands (walk, sprint) and
 // not to query.
 //
 // Specifically exec owns:
 //   - --resume: resume strategy, meaningless for a read-only query
 //
 // The constraint that at least one of --action or --pipeline must be
-// supplied is enforced in runWalk and runRun rather than here, because
+// supplied is enforced in runWalk and runSprint rather than here, because
 // cobra's MarkFlagsOneRequired cannot resolve flags inherited from parent
 // commands. See https://github.com/spf13/cobra/issues/921.
 //
 // exec is registered as a child of nav so that cobra's persistent flag
-// propagation flows: root -> nav -> exec -> walk/run
+// propagation flows: root -> nav -> exec -> walk/sprint
 func (b *Bootstrap) buildExecCommand(container *assist.CobraContainer) {
 	root := container.Root()
 

--- a/src/app/command/inputs.go
+++ b/src/app/command/inputs.go
@@ -52,7 +52,7 @@ func requireActivator(action, pipeline string) error {
 // ---------------------------------------------------------------------------
 
 // NavFamilies groups the mamba param-set pointers registered on the ghost
-// nav command as persistent flags. All navigation commands (walk, run, query)
+// nav command as persistent flags. All navigation commands (walk, sprint, query)
 // inherit these automatically through the cobra parent/child relationship.
 type NavFamilies struct {
 	Preview  *assist.ParamSet[store.PreviewParameterSet]
@@ -86,14 +86,14 @@ type WalkInputs struct {
 }
 
 // ---------------------------------------------------------------------------
-// RunInputs - consumed by the run RunE handler
+// SprintInputs - consumed by the sprint RunE handler
 // ---------------------------------------------------------------------------
 
-// RunInputs collects all flag values needed to build a run invocation.
-type RunInputs struct {
+// SprintInputs collects all flag values needed to build a sprint invocation.
+type SprintInputs struct {
 	NavFamilies
 
-	// WorkerPool holds the run-exclusive concurrency flags (--cpu, --now).
+	// WorkerPool holds the sprint-exclusive concurrency flags (--cpu, --now).
 	WorkerPool *assist.ParamSet[store.WorkerPoolParameterSet]
 }
 

--- a/src/app/command/nav-cmd.go
+++ b/src/app/command/nav-cmd.go
@@ -19,12 +19,12 @@ const (
 
 // buildNavCommand constructs the ghost nav command. It is never intended
 // to be invoked directly by the user - its sole purpose is to own the
-// persistent flag families shared by all navigation commands (walk, run,
+// persistent flag families shared by all navigation commands (walk, sprint,
 // query). By placing these families here rather than on root, utility
 // commands (verify, theme) are kept clean of navigation flags.
 //
 // nav is registered as a rooted command (child of root) so that cobra's
-// persistent flag propagation flows: root -> nav -> exec -> walk/run
+// persistent flag propagation flows: root -> nav -> exec -> walk/sprint
 //
 //	-> query
 func (b *Bootstrap) buildNavCommand(container *assist.CobraContainer) {

--- a/src/app/command/param-sets.go
+++ b/src/app/command/param-sets.go
@@ -51,7 +51,7 @@ type RootParameterSet struct {
 // ---------------------------------------------------------------------------
 
 // NavParameterSet holds the jay-specific flags inherited by all navigation
-// commands (walk, run, query) via the ghost nav command.
+// commands (walk, sprint, query) via the ghost nav command.
 type NavParameterSet struct {
 	store.ParameterSetWithOverrides
 
@@ -73,7 +73,7 @@ type NavParameterSet struct {
 // ---------------------------------------------------------------------------
 
 // ExecParameterSet holds the jay-specific flags inherited by execution
-// commands (walk, run) via the ghost exec command. Query does not inherit
+// commands (walk, sprint) via the ghost exec command. Query does not inherit
 // these flags since it performs no execution and cannot be resumed.
 type ExecParameterSet struct {
 	store.ParameterSetWithOverrides

--- a/src/app/command/settings.go
+++ b/src/app/command/settings.go
@@ -12,7 +12,7 @@ import (
 )
 
 // createSettings translates shared flag values into agenor option functions.
-// Shared between walk and run commands.
+// Shared between walk and sprint commands.
 func createSettings(families NavFamilies) []pref.Option {
 	var opts []pref.Option
 

--- a/src/app/command/sprint-cmd.go
+++ b/src/app/command/sprint-cmd.go
@@ -14,29 +14,29 @@ import (
 	"github.com/snivilised/jaywalk/src/locale"
 )
 
-func (b *Bootstrap) buildRunCommand(container *assist.CobraContainer) {
-	runCmd := &cobra.Command{
-		Use:   "run <directory>",
-		Short: li18ngo.Text(locale.RunCmdShortDescTemplData{}),
-		Long:  li18ngo.Text(locale.RunCmdLongDescTemplData{}),
+func (b *Bootstrap) buildSprintCommand(container *assist.CobraContainer) {
+	sprintCmd := &cobra.Command{
+		Use:   "sprint <directory>",
+		Short: li18ngo.Text(locale.SprintCmdShortDescTemplData{}),
+		Long:  li18ngo.Text(locale.SprintCmdLongDescTemplData{}),
 		Args:  cobra.ExactArgs(1),
-		RunE:  b.runRun,
+		RunE:  b.runSprint,
 	}
 
 	// family: worker-pool [--cpu, --now]
-	b.workerPoolFam = assist.NewParamSet[store.WorkerPoolParameterSet](runCmd)
-	b.workerPoolFam.Native.BindAll(b.workerPoolFam, runCmd.Flags())
+	b.workerPoolFam = assist.NewParamSet[store.WorkerPoolParameterSet](sprintCmd)
+	b.workerPoolFam.Native.BindAll(b.workerPoolFam, sprintCmd.Flags())
 	container.MustRegisterParamSet(WorkerPoolFamName, b.workerPoolFam)
 
-	container.MustRegisterCommand("exec", runCmd)
+	container.MustRegisterCommand("exec", sprintCmd)
 }
 
-// runRun is the RunE handler for the run command. It reads flags from
-// the nav and exec param-sets (all inherited) plus the run-exclusive
+// runSprint is the RunE handler for the sprint command. It reads flags from
+// the nav and exec param-sets (all inherited) plus the sprint-exclusive
 // worker-pool family, constructs the agenor.Hare scenario, and delegates
 // to the coordinator. The WaitGroup is owned here - the adapter created
 // it and waits on it after the coordinator returns.
-func (b *Bootstrap) runRun(cmd *cobra.Command, args []string) error {
+func (b *Bootstrap) runSprint(cmd *cobra.Command, args []string) error {
 	if err := requireActivator(b.navPs.Native.Action, b.navPs.Native.Pipeline); err != nil {
 		return err
 	}

--- a/src/app/controller/requests.go
+++ b/src/app/controller/requests.go
@@ -25,9 +25,9 @@ type Request struct {
 	PipelineName string
 
 	// Scenario is the agenor scenario provided by the command adapter.
-	// It encapsulates the walk/run distinction so the coordinator is
+	// It encapsulates the walk/sprint distinction so the coordinator is
 	// unaware of it. Set to agenor.Tortoise(isPrime) for walk or
-	// agenor.Hare(isPrime, wg) for run.
+	// agenor.Hare(isPrime, wg) for sprint.
 	Scenario agenor.Scenario
 
 	// Root is the traversal root directory. For prime traversals this is

--- a/src/app/ui/linear.go
+++ b/src/app/ui/linear.go
@@ -14,7 +14,7 @@ import (
 // and output to the prism.Renderer. It contains no formatting logic.
 //
 // Safe for concurrent use - all renderer calls are serialised through
-// a mutex so interleaved output from the run command's worker pool is
+// a mutex so interleaved output from the sprint command's worker pool is
 // avoided.
 type linear struct {
 	mu       sync.Mutex

--- a/src/locale/query-cmd-cobra-auto.go
+++ b/src/locale/query-cmd-cobra-auto.go
@@ -25,7 +25,7 @@ func (td QueryCmdLongDescTemplData) Message() *i18n.Message {
 	return &i18n.Message{
 		ID:          "query-command-long-description",
 		Description: "query acts as a non destructive directory tree inquiry",
-		Other:       "query command walks the directory tree showing nodes that  satisfy filtering criteria when present. Can be used as a kind of dry run traversal, except no actions or pipelines are invoked as in the case for walk and run commands.",
+		Other:       "query command walks the directory tree showing nodes that  satisfy filtering criteria when present. Can be used as a kind of dry run traversal, except no actions or pipelines are invoked as in the case for walk and sprint commands.",
 	}
 }
 

--- a/src/locale/sprint-cmd-cobra-auto.go
+++ b/src/locale/sprint-cmd-cobra-auto.go
@@ -8,52 +8,52 @@ import (
 )
 
 // =============================================================================
-// 🧊 RunCmdLongDesc
+// 🧊 SprintCmdLongDesc
 //
-// RunCmdLongDesc is the long description shown in cobra help output for the run
-// command.
+// SprintCmdLongDesc is the long description shown in cobra help output for the
+// sprint command.
 // =============================================================================
 
-// RunCmdLongDescTemplData Navigates a directory tree on multiple single cpu
+// SprintCmdLongDescTemplData Navigates a directory tree on multiple single cpu
 // cores and executes actions and pipelines for matching nodes.
-type RunCmdLongDescTemplData struct {
+type SprintCmdLongDescTemplData struct {
 	agenorTemplData
 }
 
-// Message returns the i18n message for RunCmdLongDescTemplData.
-func (td RunCmdLongDescTemplData) Message() *i18n.Message {
+// Message returns the i18n message for SprintCmdLongDescTemplData.
+func (td SprintCmdLongDescTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "run-command-long-description",
+		ID:          "sprint-command-long-description",
 		Description: "Navigates a directory tree on multiple single cpu cores and executes actions and pipelines for matching nodes",
 		Other: `Navigates a directory tree and executes actions and pipelines for 
 matching nodes. All actions are executed concurrently on multiple
 cpu cores. All available cpu cores can be utilised by specifying
 the --cpu flag, or a specific set of cores can be targeted using
-the --now flag. The run command is designed to be run when bulk
+the --now flag. The sprint command is designed to be run when bulk
 processing of a directory tree is required where the configured
 action is heavily IO bound. Actions and pipelines defined for walk
-run in the same way as they do for run.
+run in the same way as they do for sprint.
 Use --action or --pipeline to name a config-defined operation.
 `,
 	}
 }
 
 // =============================================================================
-// 🧊 RunCmdShortDesc
+// 🧊 SprintCmdShortDesc
 //
 // RootCmdShortDesc is the short description shown in cobra help output for the
 // root command.
 // =============================================================================
 
-// RunCmdShortDescTemplData Navigates a directory tree on a single cpu core.
-type RunCmdShortDescTemplData struct {
+// SprintCmdShortDescTemplData Navigates a directory tree on a single cpu core.
+type SprintCmdShortDescTemplData struct {
 	agenorTemplData
 }
 
-// Message returns the i18n message for RunCmdShortDescTemplData.
-func (td RunCmdShortDescTemplData) Message() *i18n.Message {
+// Message returns the i18n message for SprintCmdShortDescTemplData.
+func (td SprintCmdShortDescTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "run-command-short-description",
+		ID:          "sprint-command-short-description",
 		Description: "Navigates a directory tree on a single cpu core",
 		Other:       "Executes actions and pipelines for matching nodes on a single cpu core",
 	}

--- a/src/locale/underlying-templ-data.go
+++ b/src/locale/underlying-templ-data.go
@@ -261,39 +261,39 @@ Use --action or --pipeline to name a config-defined operation.
 	},
 
 	// -------------------------------------------------------------------------
-	// run-cmd: Cobra messages
+	// sprint-cmd: Cobra messages
 	// -------------------------------------------------------------------------
 
-	"run-command-short-description": {
-		MessageID:   "run-command-short-description",
-		Seed:        "RunCmdShortDesc",
+	"sprint-command-short-description": {
+		MessageID:   "sprint-command-short-description",
+		Seed:        "SprintCmdShortDesc",
 		TypeName:    enums.UnderlyingTypeStaticCobra,
 		Description: "Navigates a directory tree on a single cpu core",
 		Story: "RootCmdShortDesc is the short description shown in" +
 			" cobra help output for the root command.",
 		Other: "Executes actions and pipelines for matching nodes on a single cpu core",
-		File:  "run-cmd",
+		File:  "sprint-cmd",
 	},
 
-	"run-command-long-description": {
-		MessageID: "run-command-long-description",
-		Seed:      "RunCmdLongDesc",
+	"sprint-command-long-description": {
+		MessageID: "sprint-command-long-description",
+		Seed:      "SprintCmdLongDesc",
 		TypeName:  enums.UnderlyingTypeStaticCobra,
 		Description: "Navigates a directory tree on multiple single cpu cores and executes " +
 			"actions and pipelines for matching nodes",
-		Story: "RunCmdLongDesc is the long description shown in" +
-			" cobra help output for the run command.",
+		Story: "SprintCmdLongDesc is the long description shown in" +
+			" cobra help output for the sprint command.",
 		Other: `Navigates a directory tree and executes actions and pipelines for 
 matching nodes. All actions are executed concurrently on multiple
 cpu cores. All available cpu cores can be utilised by specifying
 the --cpu flag, or a specific set of cores can be targeted using
-the --now flag. The run command is designed to be run when bulk
+the --now flag. The sprint command is designed to be run when bulk
 processing of a directory tree is required where the configured
 action is heavily IO bound. Actions and pipelines defined for walk
-run in the same way as they do for run.
+run in the same way as they do for sprint.
 Use --action or --pipeline to name a config-defined operation.
 `,
-		File: "run-cmd",
+		File: "sprint-cmd",
 	},
 
 	// -------------------------------------------------------------------------
@@ -321,7 +321,7 @@ Use --action or --pipeline to name a config-defined operation.
 		Other: "query command walks the directory tree showing nodes that " +
 			" satisfy filtering criteria when present. Can be used as a kind of dry " +
 			"run traversal, except no actions or pipelines are invoked as in the case " +
-			"for walk and run commands.",
+			"for walk and sprint commands.",
 		File: "query-cmd",
 	},
 

--- a/test/data/jay-test.yml
+++ b/test/data/jay-test.yml
@@ -47,7 +47,7 @@ flags:
       cmds:
         walk:
           foo: F
-        run:
+        sprint:
           bar: Z
   # invoke defines defaults for flags not specified on the command line. Flags
   # defined here, override any that may be defined at the component level.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * The navigation execution command has been renamed from `run` to `sprint`. Users invoking the traversal command should update their command invocations from `nav exec run` to `nav exec sprint` and adjust configuration files with the new terminology.
  * All command help text and documentation have been updated to reflect the `sprint` naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->