### PR TITLE
ref(command): keep filter out of cli adapter (#463)

### DIFF
--- a/src/app/command/inputs.go
+++ b/src/app/command/inputs.go
@@ -3,32 +3,11 @@ package command
 import (
 	"strings"
 
-	"github.com/snivilised/jaywalk/src/agenor/enums"
 	"github.com/snivilised/jaywalk/src/app/report"
 	"github.com/snivilised/jaywalk/src/locale"
 	"github.com/snivilised/mamba/assist"
 	"github.com/snivilised/mamba/store"
 )
-
-// ---------------------------------------------------------------------------
-// Subscription resolution
-// ---------------------------------------------------------------------------
-
-// ResolveSubscription maps the user-supplied --subscribe string to the
-// corresponding agenor enums.Subscription value. Returns an error if the
-// value is not one of the three legal strings.
-func ResolveSubscription(flag string) (enums.Subscription, error) {
-	switch flag {
-	case SubscribeFlagFiles, "":
-		return enums.SubscribeFiles, nil
-	case SubscribeFlagDirs:
-		return enums.SubscribeDirectories, nil
-	case SubscribeFlagAll:
-		return enums.SubscribeUniversal, nil
-	default:
-		return 0, locale.ErrInvalidSubscription
-	}
-}
 
 // ---------------------------------------------------------------------------
 // Activator validation

--- a/src/app/command/query-cmd.go
+++ b/src/app/command/query-cmd.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/snivilised/jaywalk/src/agenor"
-	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/app/controller"
 	"github.com/snivilised/jaywalk/src/locale"
 )
@@ -31,13 +30,15 @@ func (b *Bootstrap) buildQueryCommand(container *assist.CobraContainer) {
 // would be invoked per node without executing it. When neither is supplied,
 // query displays the nodes that would be visited.
 func (b *Bootstrap) runQuery(cmd *cobra.Command, args []string) error {
-	subscription, err := ResolveSubscription(b.navPs.Native.Subscribe)
+	subscription, err := controller.ResolveSubscription(b.navPs.Native.Subscribe)
 	if err != nil {
 		return err
 	}
 
-	settings := createSettings(b.navFamilies())
-	settings = append(settings, pref.WithTraversalConfigurer(b.UI))
+	settings := controller.BuildTraversalSettings(
+		createTraversalSettingsIntent(b.navFamilies()),
+		b.UI,
+	)
 
 	base := controller.Request{
 		Subscription: subscription,

--- a/src/app/command/settings.go
+++ b/src/app/command/settings.go
@@ -5,77 +5,24 @@ import (
 	"strings"
 
 	"github.com/snivilised/jaywalk/src/agenor"
-	"github.com/snivilised/jaywalk/src/agenor/core"
-	"github.com/snivilised/jaywalk/src/agenor/enums"
-	"github.com/snivilised/jaywalk/src/agenor/pref"
+	"github.com/snivilised/jaywalk/src/app/controller"
 	"github.com/snivilised/jaywalk/src/locale"
 )
 
-// createSettings translates shared flag values into agenor option functions.
-// Shared between walk and sprint commands.
-func createSettings(families NavFamilies) []pref.Option {
-	var opts []pref.Option
-
-	if families.Cascade.Native.NoRecurse {
-		opts = append(opts, agenor.WithNoRecurse())
+func createTraversalSettingsIntent(families NavFamilies) controller.TraversalSettingsIntent {
+	return controller.TraversalSettingsIntent{
+		NoRecurse:     families.Cascade.Native.NoRecurse,
+		Depth:         families.Cascade.Native.Depth,
+		IsSampling:    families.Sampling.Native.IsSampling,
+		NoFiles:       families.Sampling.Native.NoFiles,
+		NoDirectories: families.Sampling.Native.NoDirectories,
+		Filter: controller.FilterIntent{
+			FilesExGlob:      families.PolyFam.Native.FilesExGlob,
+			FilesRegEx:       families.PolyFam.Native.FilesRegEx,
+			DirectoriesGlob:  families.PolyFam.Native.DirectoriesGlob,
+			DirectoriesRegEx: families.PolyFam.Native.DirectoriesRegEx,
+		},
 	}
-
-	if d := families.Cascade.Native.Depth; d > 0 {
-		opts = append(opts, agenor.WithDepth(d))
-	}
-
-	// TODO: implement DryRun on agenor
-	// if families.Preview.Native.DryRun {
-	//     opts = append(opts, agenor.WithDryRun())
-	// }
-
-	if families.Sampling.Native.IsSampling {
-		opts = append(opts, agenor.WithSamplingOptions(&pref.SamplingOptions{
-			NoOf: pref.EntryQuantities{
-				Files:       families.Sampling.Native.NoFiles,
-				Directories: families.Sampling.Native.NoDirectories,
-			},
-		}))
-	}
-
-	poly := families.PolyFam.Native
-	hasFileGlob := poly.FilesExGlob != ""
-	hasFileRegex := poly.FilesRegEx != ""
-	hasFolderGlob := poly.DirectoriesGlob != ""
-	hasFolderRegex := poly.DirectoriesRegEx != ""
-
-	if hasFileGlob || hasFileRegex || hasFolderGlob || hasFolderRegex {
-		fileDef := core.FilterDef{}
-
-		if hasFileGlob {
-			fileDef.Type = enums.FilterTypeGlob
-			fileDef.Pattern = poly.FilesExGlob
-		} else if hasFileRegex {
-			fileDef.Type = enums.FilterTypeRegex
-			fileDef.Pattern = poly.FilesRegEx
-		}
-
-		dirDef := core.FilterDef{}
-
-		if hasFolderGlob {
-			dirDef.Type = enums.FilterTypeGlob
-			dirDef.Pattern = poly.DirectoriesGlob
-		} else if hasFolderRegex {
-			dirDef.Type = enums.FilterTypeRegex
-			dirDef.Pattern = poly.DirectoriesRegEx
-		}
-
-		opts = append(opts, agenor.WithFilter(&pref.FilterOptions{
-			Node: &core.FilterDef{
-				Poly: &core.PolyFilterDef{
-					File:      fileDef,
-					Directory: dirDef,
-				},
-			},
-		}))
-	}
-
-	return opts
 }
 
 // resolveResumeStrategy maps the --resume flag string to the agenor constant.

--- a/src/app/command/sprint-cmd.go
+++ b/src/app/command/sprint-cmd.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/snivilised/jaywalk/src/agenor"
-	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/app/controller"
 	"github.com/snivilised/jaywalk/src/locale"
 )
@@ -41,13 +40,15 @@ func (b *Bootstrap) runSprint(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	subscription, err := ResolveSubscription(b.navPs.Native.Subscribe)
+	subscription, err := controller.ResolveSubscription(b.navPs.Native.Subscribe)
 	if err != nil {
 		return err
 	}
 
-	settings := createSettings(b.navFamilies())
-	settings = append(settings, pref.WithTraversalConfigurer(b.UI))
+	settings := controller.BuildTraversalSettings(
+		createTraversalSettingsIntent(b.navFamilies()),
+		b.UI,
+	)
 
 	if b.workerPoolFam.Native.CPU {
 		settings = append(settings, agenor.WithCPU())

--- a/src/app/command/walk-cmd.go
+++ b/src/app/command/walk-cmd.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/snivilised/jaywalk/src/agenor"
-	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/app/controller"
 	"github.com/snivilised/jaywalk/src/locale"
 )
@@ -31,13 +30,15 @@ func (b *Bootstrap) runWalk(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	subscription, err := ResolveSubscription(b.navPs.Native.Subscribe)
+	subscription, err := controller.ResolveSubscription(b.navPs.Native.Subscribe)
 	if err != nil {
 		return err
 	}
 
-	settings := createSettings(b.navFamilies())
-	settings = append(settings, pref.WithTraversalConfigurer(b.UI))
+	settings := controller.BuildTraversalSettings(
+		createTraversalSettingsIntent(b.navFamilies()),
+		b.UI,
+	)
 	isPrime := b.execPs.Native.Resume == ""
 
 	base := controller.Request{

--- a/src/app/controller/options.go
+++ b/src/app/controller/options.go
@@ -1,0 +1,106 @@
+package controller
+
+import (
+	"github.com/snivilised/jaywalk/src/agenor"
+	"github.com/snivilised/jaywalk/src/agenor/core"
+	"github.com/snivilised/jaywalk/src/agenor/enums"
+	"github.com/snivilised/jaywalk/src/agenor/pref"
+	"github.com/snivilised/jaywalk/src/app/report"
+	"github.com/snivilised/jaywalk/src/locale"
+)
+
+type FilterIntent struct {
+	FilesExGlob      string
+	FilesRegEx       string
+	DirectoriesGlob  string
+	DirectoriesRegEx string
+}
+
+type TraversalSettingsIntent struct {
+	NoRecurse     bool
+	Depth         uint
+	IsSampling    bool
+	NoFiles       uint
+	NoDirectories uint
+	Filter        FilterIntent
+}
+
+func BuildTraversalSettings(intent TraversalSettingsIntent, ui report.Presenter) []pref.Option {
+	var opts []pref.Option
+
+	if intent.NoRecurse {
+		opts = append(opts, agenor.WithNoRecurse())
+	}
+
+	if intent.Depth > 0 {
+		opts = append(opts, agenor.WithDepth(intent.Depth))
+	}
+
+	if intent.IsSampling {
+		opts = append(opts, agenor.WithSamplingOptions(&pref.SamplingOptions{
+			NoOf: pref.EntryQuantities{
+				Files:       intent.NoFiles,
+				Directories: intent.NoDirectories,
+			},
+		}))
+	}
+
+	if filterOption, ok := TranslateFilterIntent(intent.Filter); ok {
+		opts = append(opts, filterOption)
+	}
+
+	opts = append(opts, pref.WithTraversalConfigurer(ui))
+
+	return opts
+}
+
+func TranslateFilterIntent(intent FilterIntent) (pref.Option, bool) {
+	hasFileGlob := intent.FilesExGlob != ""
+	hasFileRegex := intent.FilesRegEx != ""
+	hasFolderGlob := intent.DirectoriesGlob != ""
+	hasFolderRegex := intent.DirectoriesRegEx != ""
+
+	if !hasFileGlob && !hasFileRegex && !hasFolderGlob && !hasFolderRegex {
+		return nil, false
+	}
+
+	fileDef := core.FilterDef{}
+	if hasFileGlob {
+		fileDef.Type = enums.FilterTypeGlob
+		fileDef.Pattern = intent.FilesExGlob
+	} else if hasFileRegex {
+		fileDef.Type = enums.FilterTypeRegex
+		fileDef.Pattern = intent.FilesRegEx
+	}
+
+	dirDef := core.FilterDef{}
+	if hasFolderGlob {
+		dirDef.Type = enums.FilterTypeGlob
+		dirDef.Pattern = intent.DirectoriesGlob
+	} else if hasFolderRegex {
+		dirDef.Type = enums.FilterTypeRegex
+		dirDef.Pattern = intent.DirectoriesRegEx
+	}
+
+	return pref.WithFilter(&pref.FilterOptions{
+		Node: &core.FilterDef{
+			Poly: &core.PolyFilterDef{
+				File:      fileDef,
+				Directory: dirDef,
+			},
+		},
+	}), true
+}
+
+func ResolveSubscription(flag string) (enums.Subscription, error) {
+	switch flag {
+	case "files", "":
+		return enums.SubscribeFiles, nil
+	case "dirs":
+		return enums.SubscribeDirectories, nil
+	case "all":
+		return enums.SubscribeUniversal, nil
+	default:
+		return 0, locale.ErrInvalidSubscription
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated subscription and traversal filter configuration logic into a centralized controller layer for improved code maintainability and consistency across navigation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->