### PR TITLE
feat(prism): improve header and summary display in linear view (#486)

### DIFF
--- a/src/agenor/core/time.go
+++ b/src/agenor/core/time.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	millisecondsDurationFormat   = "%dms"
+	secondsDurationFormat        = "%ds"
+	minutesSecondsDurationFormat = "%d:%02d"
+)
+
+// FormatDuration returns a display string for the given duration based on
+// its magnitude.
+func FormatDuration(d time.Duration) string {
+	switch {
+	case d < time.Second:
+		return FormatDurationMilliseconds(d)
+	case d < time.Minute:
+		return FormatDurationSeconds(d)
+	case d < time.Hour:
+		return FormatDurationMinutesSeconds(d)
+	default:
+		return FormatDurationFull(d)
+	}
+}
+
+// FormatDurationMilliseconds renders durations shorter than one second
+// using milliseconds only.
+func FormatDurationMilliseconds(d time.Duration) string {
+	return fmt.Sprintf(millisecondsDurationFormat, d.Milliseconds())
+}
+
+// FormatDurationSeconds renders durations shorter than one minute using
+// seconds only.
+func FormatDurationSeconds(d time.Duration) string {
+	return fmt.Sprintf(secondsDurationFormat, int(d.Seconds()))
+}
+
+// FormatDurationMinutesSeconds renders durations shorter than one hour using
+// a minute:second display format.
+func FormatDurationMinutesSeconds(d time.Duration) string {
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	return fmt.Sprintf(minutesSecondsDurationFormat, m, s)
+}
+
+// FormatDurationFull renders durations using the standard Go duration string.
+func FormatDurationFull(d time.Duration) string {
+	return d.String()
+}

--- a/src/agenor/core/time_test.go
+++ b/src/agenor/core/time_test.go
@@ -1,0 +1,30 @@
+package core_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/snivilised/jaywalk/src/agenor/core"
+)
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{name: "milliseconds", duration: 123 * time.Millisecond, expected: "123ms"},
+		{name: "seconds", duration: 5 * time.Second, expected: "5s"},
+		{name: "minutes and seconds", duration: 1*time.Minute + 2*time.Second, expected: "1:02"},
+		{name: "full duration", duration: 2*time.Hour + 3*time.Minute + 4*time.Second, expected: "2h3m4s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := core.FormatDuration(tt.duration)
+			if actual != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}

--- a/src/app/bedrock/theme-loader_test.go
+++ b/src/app/bedrock/theme-loader_test.go
@@ -32,6 +32,7 @@ palette:
     root-icon: "✻"
     directory-icon: "📁"
     file-icon: "🔖"
+    elapsed-icon: "⏰"
     branch-vertical: "│"
     branch-joint: "├── "
     branch-last: "└── "
@@ -147,14 +148,12 @@ var _ = Describe("ThemeLoader", Ordered, func() {
 				palette, err := loader.Load("my-theme")
 
 				Expect(err).To(BeNil())
-				Expect(palette.Banner.ANSI16).To(Equal("magenta"))
-				Expect(palette.Banner.ANSI256).To(Equal("99"))
-				Expect(palette.Banner.TrueColor).To(Equal("#5C4AE4"))
 				Expect(palette.Directory.ANSI16).To(Equal("cyan"))
 				Expect(palette.Error.ANSI16).To(Equal("red"))
 				Expect(palette.TreeIcons["root-icon"]).To(Equal("✻"))
 				Expect(palette.TreeIcons["directory-icon"]).To(Equal("📁"))
 				Expect(palette.TreeIcons["file-icon"]).To(Equal("🔖"))
+				Expect(palette.TreeIcons["elapsed-icon"]).To(Equal("⏰"))
 			})
 		})
 

--- a/src/prism/palette.go
+++ b/src/prism/palette.go
@@ -108,6 +108,7 @@ const (
 	TreeIconRoot           = "root-icon"
 	TreeIconDirectory      = "directory-icon"
 	TreeIconFile           = "file-icon"
+	TreeIconElapsed        = "elapsed-icon"
 	TreeIconBranchVertical = "branch-vertical"
 	TreeIconBranchJoint    = "branch-joint"
 	TreeIconBranchLast     = "branch-last"
@@ -122,14 +123,6 @@ const (
 //
 // Fields use mapstructure tags for YAML theme file decoding.
 type Palette struct {
-	// --- Navigation identity ---
-
-	// Banner is the colour of the opening traversal identity block.
-	Banner SemanticColour `mapstructure:"banner"`
-
-	// BannerText is the colour of text within the banner.
-	BannerText SemanticColour `mapstructure:"banner-text"`
-
 	// --- Traversal nodes ---
 
 	// Directory is the colour of directory names during traversal.
@@ -173,8 +166,8 @@ type Palette struct {
 
 	// --- Summary ---
 
-	// SummaryBorder is the colour of the closing summary container border.
-	SummaryBorder SemanticColour `mapstructure:"summary-border"`
+	// BoxBorder is the colour of the closing summary container border.
+	BoxBorder SemanticColour `mapstructure:"box-border"`
 
 	// SummaryLabel is the colour of labels in the closing summary.
 	SummaryLabel SemanticColour `mapstructure:"summary-label"`
@@ -200,28 +193,27 @@ type Palette struct {
 // the user has configured and requires no configuration from the caller.
 func SystemPalette() Palette {
 	return Palette{
-		Banner:        SemanticColour{ANSI16: "magenta"},
-		BannerText:    SemanticColour{ANSI16: "white"},
-		Directory:     SemanticColour{ANSI16: "cyan"},
-		File:          SemanticColour{ANSI16: "white"},
-		Root:          SemanticColour{ANSI16: "bright-white"},
-		Branch:        SemanticColour{ANSI16: "bright-black"},
-		Action:        SemanticColour{ANSI16: "blue"},
-		Pipeline:      SemanticColour{ANSI16: "blue"},
-		Skipped:       SemanticColour{ANSI16: "bright-black"},
-		Error:         SemanticColour{ANSI16: "red"},
-		Muted:         SemanticColour{ANSI16: "bright-black"},
-		Progress:      SemanticColour{ANSI16: "green"},
-		SummaryBorder: SemanticColour{ANSI16: "magenta"},
-		SummaryLabel:  SemanticColour{ANSI16: "blue"},
-		SummaryValue:  SemanticColour{ANSI16: "white"},
-		Worker:        SemanticColour{ANSI16: "cyan"},
-		WorkerIdle:    SemanticColour{ANSI16: "bright-black"},
-		LaneHeader:    SemanticColour{ANSI16: "magenta"},
+		Directory:    SemanticColour{ANSI16: "cyan"},
+		File:         SemanticColour{ANSI16: "white"},
+		Root:         SemanticColour{ANSI16: "bright-white"},
+		Branch:       SemanticColour{ANSI16: "bright-black"},
+		Action:       SemanticColour{ANSI16: "blue"},
+		Pipeline:     SemanticColour{ANSI16: "blue"},
+		Skipped:      SemanticColour{ANSI16: "bright-black"},
+		Error:        SemanticColour{ANSI16: "red"},
+		Muted:        SemanticColour{ANSI16: "bright-black"},
+		Progress:     SemanticColour{ANSI16: "green"},
+		BoxBorder:    SemanticColour{ANSI16: "magenta"},
+		SummaryLabel: SemanticColour{ANSI16: "blue"},
+		SummaryValue: SemanticColour{ANSI16: "white"},
+		Worker:       SemanticColour{ANSI16: "cyan"},
+		WorkerIdle:   SemanticColour{ANSI16: "bright-black"},
+		LaneHeader:   SemanticColour{ANSI16: "magenta"},
 		TreeIcons: TreeIcons{
 			TreeIconRoot:           "✻",
 			TreeIconDirectory:      "📁",
 			TreeIconFile:           "🔖",
+			TreeIconElapsed:        "⏰",
 			TreeIconBranchVertical: "│",
 			TreeIconBranchJoint:    "├── ",
 			TreeIconBranchLast:     "└── ",

--- a/src/prism/palette_test.go
+++ b/src/prism/palette_test.go
@@ -160,8 +160,6 @@ var _ = Describe("Palette", func() {
 			palette := prism.SystemPalette()
 
 			fields := []prism.SemanticColour{
-				palette.Banner,
-				palette.BannerText,
 				palette.Directory,
 				palette.File,
 				palette.Root,
@@ -171,7 +169,7 @@ var _ = Describe("Palette", func() {
 				palette.Error,
 				palette.Muted,
 				palette.Progress,
-				palette.SummaryBorder,
+				palette.BoxBorder,
 				palette.SummaryLabel,
 				palette.SummaryValue,
 				palette.Worker,
@@ -191,8 +189,6 @@ var _ = Describe("Palette", func() {
 			palette := prism.SystemPalette()
 
 			fields := []prism.SemanticColour{
-				palette.Banner,
-				palette.BannerText,
 				palette.Directory,
 				palette.File,
 				palette.Root,
@@ -202,7 +198,7 @@ var _ = Describe("Palette", func() {
 				palette.Error,
 				palette.Muted,
 				palette.Progress,
-				palette.SummaryBorder,
+				palette.BoxBorder,
 				palette.SummaryLabel,
 				palette.SummaryValue,
 				palette.Worker,
@@ -226,23 +222,21 @@ var _ = Describe("Palette", func() {
 			// Verify every entry has an ANSI16 value - the system palette
 			// must always be fully populated so it works without config.
 			fields := map[string]string{
-				"Banner":        palette.Banner.ANSI16,
-				"BannerText":    palette.BannerText.ANSI16,
-				"Directory":     palette.Directory.ANSI16,
-				"File":          palette.File.ANSI16,
-				"Root":          palette.Root.ANSI16,
-				"Action":        palette.Action.ANSI16,
-				"Pipeline":      palette.Pipeline.ANSI16,
-				"Skipped":       palette.Skipped.ANSI16,
-				"Error":         palette.Error.ANSI16,
-				"Muted":         palette.Muted.ANSI16,
-				"Progress":      palette.Progress.ANSI16,
-				"SummaryBorder": palette.SummaryBorder.ANSI16,
-				"SummaryLabel":  palette.SummaryLabel.ANSI16,
-				"SummaryValue":  palette.SummaryValue.ANSI16,
-				"Worker":        palette.Worker.ANSI16,
-				"WorkerIdle":    palette.WorkerIdle.ANSI16,
-				"LaneHeader":    palette.LaneHeader.ANSI16,
+				"Directory":    palette.Directory.ANSI16,
+				"File":         palette.File.ANSI16,
+				"Root":         palette.Root.ANSI16,
+				"Action":       palette.Action.ANSI16,
+				"Pipeline":     palette.Pipeline.ANSI16,
+				"Skipped":      palette.Skipped.ANSI16,
+				"Error":        palette.Error.ANSI16,
+				"Muted":        palette.Muted.ANSI16,
+				"Progress":     palette.Progress.ANSI16,
+				"BoxBorder":    palette.BoxBorder.ANSI16,
+				"SummaryLabel": palette.SummaryLabel.ANSI16,
+				"SummaryValue": palette.SummaryValue.ANSI16,
+				"Worker":       palette.Worker.ANSI16,
+				"WorkerIdle":   palette.WorkerIdle.ANSI16,
+				"LaneHeader":   palette.LaneHeader.ANSI16,
 			}
 
 			for name, ansi16 := range fields {

--- a/src/prism/stream.go
+++ b/src/prism/stream.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/third/lo"
 )
 
@@ -65,13 +66,15 @@ func (r *streamRenderer) Begin(overture Overture) {
 		caption += fmt.Sprintf("  -  from: %s", overture.ResumeFrom)
 	}
 
-	banner := r.theme.BannerStyle.Render(
-		r.theme.BannerTitleStyle.Render(title) +
-			"\n" +
-			r.theme.BannerCaptionStyle.Render(caption),
-	)
+	box := r.theme.BoxStyle.
+		MarginTop(0).
+		Render(
+			r.theme.SummaryLabelStyle.Width(0).Render(title) +
+				"\n" +
+				r.theme.SummaryValueStyle.Width(0).Render(caption),
+		)
 
-	_, _ = lipgloss.Fprintln(r.w, banner)
+	_, _ = lipgloss.Fprintln(r.w, box)
 }
 
 // Show renders a single Motif immediately to the output writer.
@@ -214,9 +217,9 @@ func (r *streamRenderer) End(summary Summary) {
 	}
 
 	lines := []string{
-		r.summaryRow(fileLabel, fmt.Sprintf("%d", summary.FilesVisited)),
-		r.summaryRow(dirLabel, fmt.Sprintf("%d", summary.DirsVisited)),
-		r.summaryRow("Elapsed", formatElapsed(summary.Elapsed)),
+		r.summaryRowWithIcon(TreeIconFile, fileLabel, fmt.Sprintf("%d", summary.FilesVisited)),
+		r.summaryRowWithIcon(TreeIconDirectory, dirLabel, fmt.Sprintf("%d", summary.DirsVisited)),
+		r.summaryRowWithIcon(TreeIconElapsed, "Elapsed", core.FormatDuration(summary.Elapsed)),
 	}
 
 	if len(summary.Errors) > 0 {
@@ -235,29 +238,22 @@ func (r *streamRenderer) End(summary Summary) {
 		}
 	}
 
-	box := r.theme.SummaryBoxStyle.Render(strings.Join(lines, "\n"))
+	box := r.theme.BoxStyle.Render(strings.Join(lines, "\n"))
 	_, _ = lipgloss.Fprintln(r.w, box)
 }
 
-// summaryRow renders a label/value pair aligned inside the summary box.
-func (r *streamRenderer) summaryRow(label, value string) string {
+// summaryRowWithIcon renders a label/value pair aligned inside the summary box,
+// prefixing the label with the requested tree icon when configured.
+func (r *streamRenderer) summaryRowWithIcon(iconKey, label, value string) string {
+	icon := r.treeIcons[iconKey]
+	if icon != "" {
+		label = icon + " " + label
+	}
+
 	return r.theme.SummaryLabelStyle.Render(label) +
 		r.theme.SummaryValueStyle.Render(value)
 }
 
-// formatElapsed produces a human-readable elapsed duration string.
-// Free function - no dependency on renderer state.
-func formatElapsed(d time.Duration) string {
-	if d < time.Second {
-		return fmt.Sprintf("%dms", d.Milliseconds())
-	}
-
-	if d < time.Minute {
-		return fmt.Sprintf("%.2fs", d.Seconds())
-	}
-
-	m := int(d.Minutes())
-	s := int(d.Seconds()) % 60
-
-	return fmt.Sprintf("%dm%ds", m, s)
+func (r *streamRenderer) summaryRow(label, value string) string {
+	return r.summaryRowWithIcon("", label, value)
 }

--- a/src/prism/stream_test.go
+++ b/src/prism/stream_test.go
@@ -2,6 +2,7 @@ package prism_test
 
 import (
 	"bytes"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -56,6 +57,7 @@ var _ = Describe("StreamRenderer", func() {
 			prism.TreeIconRoot:           "R",
 			prism.TreeIconDirectory:      "D",
 			prism.TreeIconFile:           "F",
+			prism.TreeIconElapsed:        "E",
 			prism.TreeIconBranchJoint:    "+-- ",
 			prism.TreeIconBranchLast:     "L-- ",
 			prism.TreeIconBranchVertical: "|",
@@ -83,6 +85,26 @@ var _ = Describe("StreamRenderer", func() {
 		Expect(w.String()).To(ContainSubstring("L-- F child\n"))
 	})
 
+	It("renders summary entries with tree icon prefixes", func() {
+		w := &bytes.Buffer{}
+		palette := prism.Palette{}
+
+		renderer, err := prism.New(prism.StreamView, palette, w)
+		Expect(err).To(BeNil())
+
+		renderer.End(prism.Summary{
+			Kind:         prism.PrimeNavigation,
+			FilesVisited: 12,
+			DirsVisited:  3,
+			Elapsed:      2 * time.Second,
+		})
+
+		output := w.String()
+		Expect(output).To(ContainSubstring("🔖 Files"))
+		Expect(output).To(ContainSubstring("📁 Directories"))
+		Expect(output).To(ContainSubstring("⏰ Elapsed"))
+	})
+
 	It("returns a renderer when options are provided", func() {
 		w := &bytes.Buffer{}
 		palette := prism.Palette{}
@@ -94,6 +116,27 @@ var _ = Describe("StreamRenderer", func() {
 		// exercise a simple event to ensure the renderer is operational.
 		renderer.Show(prism.Motif{Name: "test", Depth: 0, VisualDepth: 0, IsDir: true, IsLast: true})
 		Expect(w.String()).To(ContainSubstring("✻ test/"))
+	})
+
+	It("renders the banner inside the summary border style", func() {
+		w := &bytes.Buffer{}
+		palette := prism.Palette{}
+
+		renderer, err := prism.New(prism.StreamView, palette, w)
+		Expect(err).To(BeNil())
+
+		renderer.Begin(prism.Overture{
+			Kind:      prism.PrimeNavigation,
+			Root:      "./src/app",
+			Caption:   "files and folders",
+			StartedAt: time.Date(2026, time.May, 10, 11, 31, 7, 0, time.UTC),
+		})
+
+		output := w.String()
+		Expect(output).To(ContainSubstring("╭"))
+		Expect(output).To(ContainSubstring("jay  ./src/app"))
+		Expect(output).To(ContainSubstring("files and folders  -"))
+		Expect(output).To(ContainSubstring("╰"))
 	})
 
 	It("renders final directory children without vertical continuation", func() {

--- a/src/prism/theme.go
+++ b/src/prism/theme.go
@@ -13,6 +13,7 @@ func defaultTreeIcons() TreeIcons {
 		TreeIconRoot:           "✻",
 		TreeIconDirectory:      "📁",
 		TreeIconFile:           "🔖",
+		TreeIconElapsed:        "⏰",
 		TreeIconBranchVertical: "│",
 		TreeIconBranchJoint:    "├── ",
 		TreeIconBranchLast:     "└── ",
@@ -24,15 +25,6 @@ func defaultTreeIcons() TreeIcons {
 // via NewTheme and injected into the renderer. No package-level style
 // variables exist anywhere in prism.
 type Theme struct {
-	// BannerStyle is applied to the overture banner block.
-	BannerStyle lipgloss.Style
-
-	// BannerTitleStyle is applied to the title text inside the banner.
-	BannerTitleStyle lipgloss.Style
-
-	// BannerCaptionStyle is applied to the caption line inside the banner.
-	BannerCaptionStyle lipgloss.Style
-
 	// DirStyle is applied to directory name text in Show output.
 	DirStyle lipgloss.Style
 
@@ -54,8 +46,8 @@ type Theme struct {
 	// SkippedStyle is applied to nodes whose action was skipped.
 	SkippedStyle lipgloss.Style
 
-	// SummaryBoxStyle is the outer container style for the closing summary.
-	SummaryBoxStyle lipgloss.Style
+	// BoxStyle is the outer container style for the closing summary.
+	BoxStyle lipgloss.Style
 
 	// SummaryLabelStyle is applied to label text inside the summary.
 	SummaryLabelStyle lipgloss.Style
@@ -114,15 +106,6 @@ func NewTheme(palette Palette, w io.Writer) (Theme, error) {
 			return ansi, nil
 		}
 	}
-	banner, err := resolve(palette.Banner, "banner")
-	if err != nil {
-		return Theme{}, err
-	}
-
-	bannerText, err := resolve(palette.BannerText, "banner-text")
-	if err != nil {
-		return Theme{}, err
-	}
 
 	dir, err := resolve(palette.Directory, "directory")
 	if err != nil {
@@ -174,7 +157,7 @@ func NewTheme(palette Palette, w io.Writer) (Theme, error) {
 		return Theme{}, err
 	}
 
-	summaryBorder, err := resolve(palette.SummaryBorder, "summary-border")
+	BoxBorder, err := resolve(palette.BoxBorder, "box-border")
 	if err != nil {
 		return Theme{}, err
 	}
@@ -215,21 +198,6 @@ func NewTheme(palette Palette, w io.Writer) (Theme, error) {
 	}
 
 	return Theme{
-		BannerStyle: lipgloss.NewStyle().
-			Background(banner).
-			Padding(0, 2).
-			MarginBottom(1),
-
-		BannerTitleStyle: lipgloss.NewStyle().
-			Foreground(bannerText).
-			Background(banner).
-			Bold(true),
-
-		BannerCaptionStyle: lipgloss.NewStyle().
-			Foreground(bannerText).
-			Background(banner).
-			Faint(true),
-
 		DirStyle: lipgloss.NewStyle().
 			Foreground(dir).
 			Bold(true),
@@ -247,9 +215,9 @@ func NewTheme(palette Palette, w io.Writer) (Theme, error) {
 			Foreground(skipped).
 			Faint(true),
 
-		SummaryBoxStyle: lipgloss.NewStyle().
+		BoxStyle: lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(summaryBorder).
+			BorderForeground(BoxBorder).
 			Padding(0, 2).
 			MarginTop(1),
 

--- a/src/prism/theme_test.go
+++ b/src/prism/theme_test.go
@@ -52,12 +52,6 @@ var _ = Describe("Theme", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(expectedField))
 				},
-				Entry("banner",
-					func(p *prism.Palette) {
-						p.Banner = prism.SemanticColour{ANSI16: "notacolour"}
-					},
-					"palette.banner",
-				),
 				Entry("directory",
 					func(p *prism.Palette) {
 						p.Directory = prism.SemanticColour{ANSI16: "notacolour"}

--- a/test/data/rounded-tree.theme.yml
+++ b/test/data/rounded-tree.theme.yml
@@ -1,21 +1,9 @@
 # Default theme configuration for jaywalk prism renderer
 # This file demonstrates all available theme options with their default values.
 # Copy this file and modify the values to customize your theme.
+# NB: true-color values must contain a lead #.
 
-# --- Navigation identity ---
 palette:
-  # Banner is the colour of the opening traversal identity block.
-  banner:
-    ansi16: magenta
-    ansi256: ""
-    true-color: ""
-
-  # BannerText is the colour of text within the banner.
-  banner-text:
-    ansi16: white
-    ansi256: ""
-    true-color: ""
-
   # --- Traversal nodes ---
 
   # Directory is the colour of directory names during traversal.
@@ -85,8 +73,8 @@ palette:
 
   # --- Summary ---
 
-  # SummaryBorder is the colour of the closing summary container border.
-  summary-border:
+  # BoxBorder is the colour of the closing summary container border.
+  box-border:
     ansi16: magenta
     ansi256: ""
     true-color: ""
@@ -129,6 +117,7 @@ tree-icons:
   root-icon: "✻"
   directory-icon: "📁"
   file-icon: "🔖"
+  elapsed-icon: "⏰"
   branch-vertical: "│"
   branch-joint: "├── "
   branch-last: "╰── "

--- a/test/data/square-tree.theme.yml
+++ b/test/data/square-tree.theme.yml
@@ -1,21 +1,9 @@
 # Default theme configuration for jaywalk prism renderer
 # This file demonstrates all available theme options with their default values.
 # Copy this file and modify the values to customize your theme.
+# NB: true-color values must contain a lead #.
 
-# --- Navigation identity ---
 palette:
-  # Banner is the colour of the opening traversal identity block.
-  banner:
-    ansi16: magenta
-    ansi256: ""
-    true-color: ""
-
-  # BannerText is the colour of text within the banner.
-  banner-text:
-    ansi16: white
-    ansi256: ""
-    true-color: ""
-
   # --- Traversal nodes ---
 
   # Directory is the colour of directory names during traversal.
@@ -85,8 +73,8 @@ palette:
 
   # --- Summary ---
 
-  # SummaryBorder is the colour of the closing summary container border.
-  summary-border:
+  # BoxBorder is the colour of the closing summary container border.
+  box-border:
     ansi16: magenta
     ansi256: ""
     true-color: ""
@@ -129,6 +117,7 @@ tree-icons:
   root-icon: "✻"
   directory-icon: "📁"
   file-icon: "🔖"
+  elapsed-icon: "⏰"
   branch-vertical: "│"
   branch-joint: "├── "
   branch-last: "└── "


### PR DESCRIPTION
feat(prism): make header style match summary (#486)

feat(prism): render elasped time according to duration (#486)

feat(prism): add icons to summary entries (#486)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added duration formatting with intelligent unit selection (milliseconds, seconds, minutes:seconds, full format)
  * Added elapsed-time icon support (⏰) for tree-style rendering
  * Introduced box-border styling for summary containers

* **Refactor**
  * Replaced banner styling with unified box styling throughout the rendering pipeline
  * Integrated duration formatter for elapsed-time display with icon prefixes

* **Tests**
  * Comprehensive test coverage for duration formatting and theme rendering updates

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snivilised/jaywalk/pull/490)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->