### PR TITLE
ref(prism): move stream into new linearview package (#498)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -133,6 +133,7 @@
     "Kriket",
     "leaktest",
     "leftfield",
+    "linearview",
     "linecomment",
     "linters",
     "lipgloss",

--- a/src/app/command/bootstrap.go
+++ b/src/app/command/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snivilised/jaywalk/src/app/report"
 	"github.com/snivilised/jaywalk/src/app/shell"
 	"github.com/snivilised/jaywalk/src/app/ui"
+	"github.com/snivilised/jaywalk/src/prism/flow"
 )
 
 // ---------------------------------------------------------------------------
@@ -211,12 +212,24 @@ func (b *Bootstrap) Root(options ...ConfigureAppOptionFn) *cobra.Command {
 			Version: fmt.Sprintf("'%v'", Version),
 
 			PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+				mode := b.rootPs.Native.TUI
+				if mode == "" {
+					mode = ui.ModeDefault
+				}
+
+				// Register only the selected view factory; avoid registering
+				// all known views when only one will be used.
+				switch mode {
+				case ui.ModeLinear:
+					flow.Register()
+				}
+
 				palette, err := b.themeLoader.Load(b.rootPs.Native.Theme)
 				if err != nil {
 					return err
 				}
 
-				mgr, err := ui.New(b.rootPs.Native.TUI, palette)
+				mgr, err := ui.New(mode, palette)
 				if err != nil {
 					return err
 				}

--- a/src/app/ui/linear.go
+++ b/src/app/ui/linear.go
@@ -10,7 +10,7 @@ import (
 	"github.com/snivilised/jaywalk/src/third/lo"
 )
 
-// linear is the stream-view display implementation. It translates
+// linear is the linear-view display implementation. It translates
 // report events into prism.Motif calls and delegates all formatting
 // and output to the prism.Renderer. It contains no formatting logic.
 //

--- a/src/app/ui/registry.go
+++ b/src/app/ui/registry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/snivilised/jaywalk/src/app/report"
 	"github.com/snivilised/jaywalk/src/prism"
+	"github.com/snivilised/jaywalk/src/prism/flow"
 )
 
 // ---------------------------------------------------------------------------
@@ -14,8 +15,8 @@ import (
 // ---------------------------------------------------------------------------
 
 const (
-	// ModeLinear is the default stream view. One styled line per node
-	// via prism's stream renderer with lipgloss formatting.
+	// ModeLinear is the default linear view. One styled line per node
+	// via prism's linear renderer with lipgloss formatting.
 	ModeLinear = "linear"
 
 	// ModeDefault is the display used when --tui is not specified.
@@ -26,17 +27,16 @@ const (
 // View factory functions - on-demand creation
 // ---------------------------------------------------------------------------
 
-// newLinearPresenter creates a linear stream view presenter with the
-// given palette. The presenter wraps a prism stream renderer and
+// newLinearPresenter creates a linear view presenter with the
+// given palette. The presenter wraps a prism linear renderer and
 // applies the palette's theme settings (colors, icons, styles). Custom
 // tree icons from the palette are explicitly applied via WithIcons to
 // ensure they override the defaults.
 func newLinearPresenter(palette prism.Palette) (report.Presenter, error) {
-	renderer, err := prism.New(
-		prism.StreamView,
+	renderer, err := flow.New(
 		palette,
 		os.Stdout,
-		prism.WithIcons(palette.TreeIcons),
+		flow.WithIcons(palette.TreeIcons),
 	)
 	if err != nil {
 		return nil, err

--- a/src/prism/doc.go
+++ b/src/prism/doc.go
@@ -1,6 +1,3 @@
 // package prism defines presentation layer used by jay, assisted by the charm
 // universe. prism is also designed to be used by third parties.
 package prism
-
-// side note, lipgloss is installed with:
-// go get charm.land/lipgloss/v2@v2.0.3

--- a/src/prism/flow/doc.go
+++ b/src/prism/flow/doc.go
@@ -1,0 +1,14 @@
+// package flow implements the linear view renderer and presenter.
+// The linear view is a simple, vertically scrolling output format with one styled
+// line per node. It is the default view for jaywalk and is designed for
+// maximum compatibility with a wide range of terminal environments.
+//
+// The linear renderer is implemented in this package and registered as the
+// factory for prism.LinearView. The linear presenter is implemented in the
+// app/ui package and wraps the linear renderer to translate report events
+// into prism.Motif calls.
+//
+// The linear view supports custom tree icons via the palette's TreeIcons map.
+// These icons are applied to the linear renderer via the WithIcons option at
+// construction time. Custom icons override the defaults provided by prism.
+package flow

--- a/src/prism/flow/flow-suite_test.go
+++ b/src/prism/flow/flow-suite_test.go
@@ -1,0 +1,13 @@
+package flow_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFlow(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flow Suite")
+}

--- a/src/prism/flow/linear-new.go
+++ b/src/prism/flow/linear-new.go
@@ -1,0 +1,36 @@
+package flow
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/snivilised/jaywalk/src/prism"
+)
+
+// New constructs a linear renderer for linear-style output.
+func New(palette prism.Palette, writer io.Writer, opts ...LinearOption) (prism.Renderer, error) {
+	theme, err := prism.NewTheme(palette, writer)
+	if err != nil {
+		return nil, fmt.Errorf("flow.New: %w", err)
+	}
+
+	r := &renderer{
+		theme:     theme,
+		writer:    writer,
+		treeIcons: theme.TreeIcons,
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r, nil
+}
+
+// Register installs the linear view factory into prism's shared factory map.
+// Call this explicitly during application bootstrap before invoking prism.New.
+func Register() {
+	prism.RegisterFactory(prism.LinearView, func(palette prism.Palette, writer io.Writer) (prism.Renderer, error) {
+		return New(palette, writer)
+	})
+}

--- a/src/prism/flow/linear-options.go
+++ b/src/prism/flow/linear-options.go
@@ -1,0 +1,20 @@
+package flow
+
+// LinearOption configures linear renderer behavior at construction time.
+type LinearOption func(*renderer)
+
+// WithIcons configures tree glyphs and item icons for linear renderers.
+// The map keys are the standard token names used by prism tree rendering.
+func WithIcons(icons map[string]string) LinearOption {
+	return func(r *renderer) {
+		if r.treeIcons == nil {
+			r.treeIcons = make(map[string]string)
+		}
+
+		for key, value := range icons {
+			if value != "" {
+				r.treeIcons[key] = value
+			}
+		}
+	}
+}

--- a/src/prism/flow/linear-renderer.go
+++ b/src/prism/flow/linear-renderer.go
@@ -1,4 +1,9 @@
-package prism
+// Package flow contains the linear renderer implementation and its
+// view-specific options.
+//
+// Dependency rule: this package imports root prism contracts, but root prism
+// must not import this package to avoid import cycles.
+package flow
 
 import (
 	"fmt"
@@ -8,50 +13,32 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/snivilised/jaywalk/src/agenor/core"
+	"github.com/snivilised/jaywalk/src/prism"
 	"github.com/snivilised/jaywalk/src/third/lo"
 )
 
-// streamRenderer is the linear scrolling view. Output is written
-// immediately as events arrive - no internal buffering. Implements
-// Renderer.
-type streamRenderer struct {
-	theme  Theme
+// renderer is the linear scrolling view. Output is written immediately as
+// events arrive - no internal buffering.
+type renderer struct {
+	theme  prism.Theme
 	writer io.Writer
 
-	// treeIcons holds configured tree glyphs, either from the theme or
-	// from renderer options such as WithIcons.
-	treeIcons TreeIcons
+	// treeIcons holds configured tree glyphs from the resolved theme/options.
+	treeIcons prism.TreeIcons
 
-	// branchStack tracks ancestor continuation state for tree branch
-	// rendering.
+	// branchStack tracks ancestor continuation state for tree branch rendering.
 	branchStack []bool
 
 	previousDepth  core.TraversalDepth
 	previousIsLast bool
 }
 
-// newStreamRenderer constructs a streamRenderer. Called by New() when
-// ViewKind is StreamView. Unexported - callers use New().
-func newStreamRenderer(theme Theme, writer io.Writer, opts ...RendererOption) Renderer {
-	r := &streamRenderer{
-		theme:     theme,
-		writer:    writer,
-		treeIcons: theme.TreeIcons,
-	}
-
-	for _, opt := range opts {
-		opt(r)
-	}
-
-	return r
-}
-
-// Begin renders the opening banner using the Overture metadata. The
-// banner adapts to indicate prime or resume traversal.
-func (r *streamRenderer) Begin(overture Overture) {
+// Begin renders the opening banner using the Overture metadata. The banner
+// adapts to indicate prime or resume traversal.
+func (r *renderer) Begin(overture prism.Overture) {
 	var title string
 
-	if overture.Kind == ResumeNavigation {
+	if overture.Kind == prism.ResumeNavigation {
 		title = fmt.Sprintf("  jay  resuming %s", overture.Root)
 	} else {
 		title = fmt.Sprintf("  jay  %s", overture.Root)
@@ -62,7 +49,7 @@ func (r *streamRenderer) Begin(overture Overture) {
 		overture.StartedAt.Format(time.RFC1123),
 	)
 
-	if overture.Kind == ResumeNavigation && overture.ResumeFrom != "" {
+	if overture.Kind == prism.ResumeNavigation && overture.ResumeFrom != "" {
 		caption += fmt.Sprintf("  -  from: %s", overture.ResumeFrom)
 	}
 
@@ -78,9 +65,7 @@ func (r *streamRenderer) Begin(overture Overture) {
 }
 
 // Show renders a single Motif immediately to the output writer.
-// Errors, skips, actions, pipelines, directories and files each receive
-// distinct visual treatment.
-func (r *streamRenderer) Show(motif Motif) {
+func (r *renderer) Show(motif prism.Motif) {
 	prefix := r.branchPrefix(motif)
 	depth := r.theme.BranchStyle.Render(prefix)
 
@@ -110,10 +95,10 @@ func (r *streamRenderer) Show(motif Motif) {
 	r.updateBranchStack(motif)
 }
 
-func (r *streamRenderer) itemLabel(motif Motif) string {
-	icon := r.treeIcons[TreeIconFile]
+func (r *renderer) itemLabel(motif prism.Motif) string {
+	icon := r.treeIcons[prism.TreeIconFile]
 	if motif.IsDir {
-		icon = r.treeIcons[TreeIconDirectory]
+		icon = r.treeIcons[prism.TreeIconDirectory]
 	}
 
 	label := ""
@@ -128,11 +113,9 @@ func (r *streamRenderer) itemLabel(motif Motif) string {
 	return label
 }
 
-// renderSkipped renders a skipped item with the reason shown in brackets.
-func (r *streamRenderer) renderSkipped(motif Motif) string {
+func (r *renderer) renderSkipped(motif prism.Motif) string {
 	var b strings.Builder
 
-	// Render the item name with skip indicator
 	itemName := "~ " + motif.Name
 	if motif.IsDir {
 		itemName += "/"
@@ -141,7 +124,6 @@ func (r *streamRenderer) renderSkipped(motif Motif) string {
 		b.WriteString(r.theme.FileStyle.Render(itemName))
 	}
 
-	// Render the skip reason
 	skipReason := fmt.Sprintf("  [skipped: %s -> %s]",
 		motif.Placeholder,
 		motif.ResolvedPath,
@@ -151,11 +133,10 @@ func (r *streamRenderer) renderSkipped(motif Motif) string {
 	return b.String()
 }
 
-// renderRoot renders the root item with configured icon.
-func (r *streamRenderer) renderRoot(motif Motif) string {
+func (r *renderer) renderRoot(motif prism.Motif) string {
 	var b strings.Builder
 
-	icon := r.treeIcons[TreeIconRoot]
+	icon := r.treeIcons[prism.TreeIconRoot]
 	if icon != "" {
 		b.WriteString(icon)
 		b.WriteString(" ")
@@ -169,8 +150,7 @@ func (r *streamRenderer) renderRoot(motif Motif) string {
 	return r.theme.RootStyle.Render(b.String())
 }
 
-// renderDir renders a directory item with optional action or pipeline metadata.
-func (r *streamRenderer) renderDir(motif Motif) string {
+func (r *renderer) renderDir(motif prism.Motif) string {
 	var b strings.Builder
 
 	b.WriteString(r.theme.DirStyle.Render(r.itemLabel(motif)))
@@ -179,8 +159,7 @@ func (r *streamRenderer) renderDir(motif Motif) string {
 	return b.String()
 }
 
-// renderFile renders a file item with optional action or pipeline metadata.
-func (r *streamRenderer) renderFile(motif Motif) string {
+func (r *renderer) renderFile(motif prism.Motif) string {
 	var b strings.Builder
 
 	b.WriteString(r.theme.FileStyle.Render(r.itemLabel(motif)))
@@ -189,9 +168,7 @@ func (r *streamRenderer) renderFile(motif Motif) string {
 	return b.String()
 }
 
-// renderActionOrPipeline renders action or pipeline metadata if present.
-// Returns empty string if neither action nor pipeline is configured.
-func (r *streamRenderer) renderActionOrPipeline(motif Motif) string {
+func (r *renderer) renderActionOrPipeline(motif prism.Motif) string {
 	var b strings.Builder
 
 	if motif.ActionName != "" {
@@ -205,8 +182,7 @@ func (r *streamRenderer) renderActionOrPipeline(motif Motif) string {
 	return b.String()
 }
 
-// renderExecutionInfo renders the execution result (dry-run indicator or command output).
-func (r *streamRenderer) renderExecutionInfo(motif Motif) string {
+func (r *renderer) renderExecutionInfo(motif prism.Motif) string {
 	if motif.DryRun {
 		return r.theme.LandingStripStyle.Render(" [" + motif.ExecutionString + "]")
 	} else if motif.CommandOutput != "" {
@@ -216,33 +192,33 @@ func (r *streamRenderer) renderExecutionInfo(motif Motif) string {
 	return ""
 }
 
-func (r *streamRenderer) branchPrefix(motif Motif) string {
+func (r *renderer) branchPrefix(motif prism.Motif) string {
 	if motif.VisualDepth == 0 {
 		return ""
 	}
 
 	var b strings.Builder
-	//nolint:gosec // ok - branchStack is only modified by updateBranchStack based on motif.VisualDepth
+	//nolint:gosec // branchStack is only modified by updateBranchStack based on motif.VisualDepth.
 	for level := 1; level < int(motif.VisualDepth); level++ {
 		if level-1 < len(r.branchStack) && r.branchStack[level-1] {
-			b.WriteString(r.treeIcons[TreeIconBranchVertical])
-			b.WriteString(r.treeIcons[TreeIconBranchIndent])
+			b.WriteString(r.treeIcons[prism.TreeIconBranchVertical])
+			b.WriteString(r.treeIcons[prism.TreeIconBranchIndent])
 		} else {
 			b.WriteString(
 				strings.Repeat(" ",
-					len(r.treeIcons[TreeIconBranchVertical])+len(r.treeIcons[TreeIconBranchIndent]),
+					len(r.treeIcons[prism.TreeIconBranchVertical])+len(r.treeIcons[prism.TreeIconBranchIndent]),
 				),
 			)
 		}
 	}
 
-	branchIcon := lo.Ternary(motif.IsLast, TreeIconBranchLast, TreeIconBranchJoint)
+	branchIcon := lo.Ternary(motif.IsLast, prism.TreeIconBranchLast, prism.TreeIconBranchJoint)
 	b.WriteString(r.treeIcons[branchIcon])
 
 	return b.String()
 }
 
-func (r *streamRenderer) updateBranchStack(motif Motif) {
+func (r *renderer) updateBranchStack(motif prism.Motif) {
 	if motif.VisualDepth == 0 {
 		r.branchStack = nil
 		r.previousDepth = motif.VisualDepth
@@ -266,21 +242,20 @@ func (r *streamRenderer) updateBranchStack(motif Motif) {
 	r.previousIsLast = motif.IsLast
 }
 
-// End renders the closing summary box with traversal counts, elapsed
-// time, and any errors. Labels adapt for resume traversals.
-func (r *streamRenderer) End(summary Summary) {
+// End renders the closing summary box with traversal counts and elapsed time.
+func (r *renderer) End(summary prism.Summary) {
 	fileLabel := "Files"
 	dirLabel := "Directories"
 
-	if summary.Kind == ResumeNavigation {
+	if summary.Kind == prism.ResumeNavigation {
 		fileLabel = "Files (resumed)"
 		dirLabel = "Dirs (resumed)"
 	}
 
 	lines := []string{
-		r.summaryRowWithIcon(TreeIconFile, fileLabel, fmt.Sprintf("%d", summary.FilesVisited)),
-		r.summaryRowWithIcon(TreeIconDirectory, dirLabel, fmt.Sprintf("%d", summary.DirsVisited)),
-		r.summaryRowWithIcon(TreeIconElapsed, "Elapsed", core.FormatDuration(summary.Elapsed)),
+		r.summaryRowWithIcon(prism.TreeIconFile, fileLabel, fmt.Sprintf("%d", summary.FilesVisited)),
+		r.summaryRowWithIcon(prism.TreeIconDirectory, dirLabel, fmt.Sprintf("%d", summary.DirsVisited)),
+		r.summaryRowWithIcon(prism.TreeIconElapsed, "Elapsed", core.FormatDuration(summary.Elapsed)),
 	}
 
 	if len(summary.Errors) > 0 {
@@ -303,9 +278,7 @@ func (r *streamRenderer) End(summary Summary) {
 	_, _ = lipgloss.Fprintln(r.writer, box)
 }
 
-// summaryRowWithIcon renders a label/value pair aligned inside the summary box,
-// prefixing the label with the requested tree icon when configured.
-func (r *streamRenderer) summaryRowWithIcon(iconKey, label, value string) string {
+func (r *renderer) summaryRowWithIcon(iconKey, label, value string) string {
 	icon := r.treeIcons[iconKey]
 	if icon != "" {
 		label = icon + " " + label
@@ -315,6 +288,6 @@ func (r *streamRenderer) summaryRowWithIcon(iconKey, label, value string) string
 		r.theme.SummaryValueStyle.Render(value)
 }
 
-func (r *streamRenderer) summaryRow(label, value string) string {
+func (r *renderer) summaryRow(label, value string) string {
 	return r.summaryRowWithIcon("", label, value)
 }

--- a/src/prism/flow/linear-renderer_test.go
+++ b/src/prism/flow/linear-renderer_test.go
@@ -1,4 +1,4 @@
-package prism_test
+package flow_test
 
 import (
 	"bytes"
@@ -8,14 +8,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/snivilised/jaywalk/src/prism"
+	"github.com/snivilised/jaywalk/src/prism/flow"
 )
 
-var _ = Describe("StreamRenderer", func() {
+var _ = Describe("LinearRenderer", func() {
 	It("renders tree branches with default icons", func() {
 		w := &bytes.Buffer{}
 		palette := prism.Palette{}
 
-		renderer, err := prism.New(prism.StreamView, palette, w)
+		renderer, err := flow.New(palette, w)
 		Expect(err).To(BeNil())
 		Expect(renderer).NotTo(BeNil())
 
@@ -53,7 +54,7 @@ var _ = Describe("StreamRenderer", func() {
 		w := &bytes.Buffer{}
 		palette := prism.Palette{}
 
-		renderer, err := prism.New(prism.StreamView, palette, w, prism.WithIcons(map[string]string{
+		renderer, err := flow.New(palette, w, flow.WithIcons(map[string]string{
 			prism.TreeIconRoot:           "R",
 			prism.TreeIconDirectory:      "D",
 			prism.TreeIconFile:           "F",
@@ -89,7 +90,7 @@ var _ = Describe("StreamRenderer", func() {
 		w := &bytes.Buffer{}
 		palette := prism.Palette{}
 
-		renderer, err := prism.New(prism.StreamView, palette, w)
+		renderer, err := flow.New(palette, w)
 		Expect(err).To(BeNil())
 
 		renderer.End(prism.Summary{
@@ -109,11 +110,10 @@ var _ = Describe("StreamRenderer", func() {
 		w := &bytes.Buffer{}
 		palette := prism.Palette{}
 
-		renderer, err := prism.New(prism.StreamView, palette, w, prism.WithIcons(nil))
+		renderer, err := flow.New(palette, w, flow.WithIcons(nil))
 		Expect(err).To(BeNil())
 		Expect(renderer).NotTo(BeNil())
 		Expect(renderer).To(Not(BeNil()))
-		// exercise a simple event to ensure the renderer is operational.
 		renderer.Show(prism.Motif{Name: "test", Depth: 0, VisualDepth: 0, IsDir: true, IsLast: true})
 		Expect(w.String()).To(ContainSubstring("✻ test/"))
 	})
@@ -122,7 +122,7 @@ var _ = Describe("StreamRenderer", func() {
 		w := &bytes.Buffer{}
 		palette := prism.Palette{}
 
-		renderer, err := prism.New(prism.StreamView, palette, w)
+		renderer, err := flow.New(palette, w)
 		Expect(err).To(BeNil())
 
 		renderer.Begin(prism.Overture{
@@ -143,86 +143,31 @@ var _ = Describe("StreamRenderer", func() {
 		w := &bytes.Buffer{}
 		palette := prism.Palette{}
 
-		renderer, err := prism.New(prism.StreamView, palette, w)
+		renderer, err := flow.New(palette, w)
 		Expect(err).To(BeNil())
 
-		// Root directory
-		renderer.Show(prism.Motif{
-			Name:        "src",
-			IsDir:       true,
-			Depth:       0,
-			VisualDepth: 0,
-			IsLast:      true,
-		})
-
-		// First child directory (not last)
-		renderer.Show(prism.Motif{
-			Name:        "app",
-			IsDir:       true,
-			Depth:       1,
-			VisualDepth: 1,
-			IsLast:      false,
-		})
-
-		// File under first child
-		renderer.Show(prism.Motif{
-			Name:        "main.go",
-			IsDir:       false,
-			Depth:       2,
-			VisualDepth: 2,
-			IsLast:      true,
-		})
-
-		// Final child directory (last)
-		renderer.Show(prism.Motif{
-			Name:        "ui",
-			IsDir:       true,
-			Depth:       1,
-			VisualDepth: 1,
-			IsLast:      true,
-		})
-
-		// File under final child
-		renderer.Show(prism.Motif{
-			Name:        "doc.go",
-			IsDir:       false,
-			Depth:       2,
-			VisualDepth: 2,
-			IsLast:      true,
-		})
+		renderer.Show(prism.Motif{Name: "src", IsDir: true, Depth: 0, VisualDepth: 0, IsLast: true})
+		renderer.Show(prism.Motif{Name: "app", IsDir: true, Depth: 1, VisualDepth: 1, IsLast: false})
+		renderer.Show(prism.Motif{Name: "main.go", IsDir: false, Depth: 2, VisualDepth: 2, IsLast: true})
+		renderer.Show(prism.Motif{Name: "ui", IsDir: true, Depth: 1, VisualDepth: 1, IsLast: true})
+		renderer.Show(prism.Motif{Name: "doc.go", IsDir: false, Depth: 2, VisualDepth: 2, IsLast: true})
 
 		output := w.String()
-		// The final directory should show with branch-last
 		Expect(output).To(ContainSubstring("└── 📁 ui/"))
-		// Its children should not have vertical continuation (no │ prefix)
 		Expect(output).To(ContainSubstring("   └── 🔖 doc.go"))
 	})
 
 	It("applies BranchStyle from theme to branch characters", func() {
 		w := &bytes.Buffer{}
-		// Create a palette with explicit branch color
 		palette := prism.SystemPalette()
 		palette.Branch = prism.SemanticColour{ANSI16: "green"}
 
-		renderer, err := prism.New(prism.StreamView, palette, w)
+		renderer, err := flow.New(palette, w)
 		Expect(err).To(BeNil())
 		Expect(renderer).NotTo(BeNil())
 
-		renderer.Show(prism.Motif{
-			Name:        "root",
-			IsDir:       true,
-			Depth:       0,
-			VisualDepth: 0,
-			IsLast:      true,
-		})
-
-		renderer.Show(prism.Motif{
-			Name:        "child",
-			IsDir:       false,
-			Depth:       1,
-			VisualDepth: 1,
-			IsLast:      true,
-		})
+		renderer.Show(prism.Motif{Name: "root", IsDir: true, Depth: 0, VisualDepth: 0, IsLast: true})
+		renderer.Show(prism.Motif{Name: "child", IsDir: false, Depth: 1, VisualDepth: 1, IsLast: true})
 
 		output := w.String()
 		Expect(output).To(ContainSubstring("✻ root/\n"))

--- a/src/prism/palette.go
+++ b/src/prism/palette.go
@@ -138,7 +138,7 @@ type Palette struct {
 	Branch SemanticColour `mapstructure:"branch"`
 
 	// TreeIcons holds optional glyph configuration used by tree-style
-	// stream renderers such as the linear view.
+	// linear renderers such as the linear view.
 	TreeIcons TreeIcons `mapstructure:"tree-icons"`
 
 	// --- Execution ---

--- a/src/prism/prism-new.go
+++ b/src/prism/prism-new.go
@@ -1,0 +1,46 @@
+package prism
+
+import (
+	"fmt"
+	"io"
+)
+
+type rendererFactory func(Palette, io.Writer) (Renderer, error)
+
+var factories = map[ViewKind]rendererFactory{}
+
+// RegisterFactory allows view-specific packages to register their constructor
+// without prism importing those packages directly.
+func RegisterFactory(kind ViewKind, factory func(Palette, io.Writer) (Renderer, error)) {
+	factories[kind] = factory
+}
+
+// New constructs a Renderer for the requested view kind using the given
+// Palette. The Writer writer is the output destination; pass os.Stdout for
+// production use or a bytes.Buffer in tests.
+//
+// Returns an error if the Palette contains unrecognised colour names,
+// which would indicate a malformed user theme file. Bootstrap should
+// treat this as a startup failure.
+func New(kind ViewKind, palette Palette, writer io.Writer) (Renderer, error) {
+	factory := factories[kind]
+
+	switch {
+	case factory != nil:
+		renderer, err := factory(palette, writer)
+		if err != nil {
+			return nil, fmt.Errorf("prism.New: %w", err)
+		}
+		return renderer, nil
+	default:
+		fallback := factories[LinearView]
+		if fallback == nil {
+			return nil, fmt.Errorf("prism.New: no renderer factory registered for view %q", kind)
+		}
+		renderer, err := fallback(palette, writer)
+		if err != nil {
+			return nil, fmt.Errorf("prism.New: %w", err)
+		}
+		return renderer, nil
+	}
+}

--- a/src/prism/prism.go
+++ b/src/prism/prism.go
@@ -1,12 +1,17 @@
 package prism
 
 import (
-	"fmt"
-	"io"
 	"time"
 
 	"github.com/snivilised/jaywalk/src/agenor/core"
 )
+
+// Dependency rule for prism view packages:
+// - root prism contains only shared, view-neutral contracts and factory APIs;
+// - view-specific implementation/options live in dedicated sub-packages
+//   (for example prism/flow);
+// - root prism must not import view-specific sub-packages. Views register
+//   factories into prism, which prevents prism -> view -> prism import cycles.
 
 // ViewKind identifies the rendering view to use. Defined as a typed
 // string rather than an iota so that the set remains open - new views
@@ -14,8 +19,8 @@ import (
 type ViewKind string
 
 const (
-	// StreamView is a linear scrolling output view rendered with lipgloss.
-	StreamView ViewKind = "stream"
+	// LinearView is a linear scrolling output view rendered with lipgloss.
+	LinearView ViewKind = "linear"
 
 	// PortholeView is a bubbletea view with a static header and footer
 	// and vertically scrolling content between them.
@@ -73,7 +78,7 @@ type Overture struct {
 	ResumeFrom string
 
 	// Survey holds the results of a prior survey phase. Nil for
-	// single-phase navigations such as the stream view.
+	// single-phase navigations such as the linear view.
 	Survey *SurveyResult
 }
 
@@ -176,45 +181,4 @@ type Renderer interface {
 
 	// End is called once when traversal completes.
 	End(summary Summary)
-}
-
-// RendererOption configures renderer behavior at construction time.
-type RendererOption func(*streamRenderer)
-
-// WithIcons configures tree glyphs and item icons for stream renderers.
-// The map keys are the standard token names used by prism tree rendering.
-func WithIcons(icons map[string]string) RendererOption {
-	return func(r *streamRenderer) {
-		if r.treeIcons == nil {
-			r.treeIcons = make(map[string]string)
-		}
-
-		for key, value := range icons {
-			if value != "" {
-				r.treeIcons[key] = value
-			}
-		}
-	}
-}
-
-// New constructs a Renderer for the requested view kind using the given
-// Palette. The Writer writer is the output destination; pass os.Stdout for
-// production use or a bytes.Buffer in tests.
-//
-// Returns an error if the Palette contains unrecognised colour names,
-// which would indicate a malformed user theme file. Bootstrap should
-// treat this as a startup failure.
-func New(kind ViewKind, palette Palette, writer io.Writer, opts ...RendererOption) (Renderer, error) {
-	theme, err := NewTheme(palette, writer)
-	if err != nil {
-		return nil, fmt.Errorf("prism.New: %w", err)
-	}
-
-	//nolint:exhaustive // prism.PortholeView, prism.LanesView
-	switch kind {
-	case StreamView:
-		return newStreamRenderer(theme, writer, opts...), nil
-	default:
-		return newStreamRenderer(theme, writer, opts...), nil
-	}
 }

--- a/src/prism/prism_test.go
+++ b/src/prism/prism_test.go
@@ -7,9 +7,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/snivilised/jaywalk/src/prism"
+	"github.com/snivilised/jaywalk/src/prism/flow"
 )
 
 var _ = Describe("New", func() {
+	BeforeEach(func() {
+		flow.Register()
+	})
 
 	Context("when given a valid palette", func() {
 		DescribeTable("returns a non-nil Renderer for known view kinds",
@@ -22,11 +26,11 @@ var _ = Describe("New", func() {
 				Expect(err).To(BeNil())
 				Expect(renderer).NotTo(BeNil())
 			},
-			Entry("stream view", prism.StreamView),
+			Entry("linear view", prism.LinearView),
 		)
 
 		Context("when given an unknown view kind", func() {
-			It("falls back to the stream renderer without error", func() {
+			It("falls back to the linear renderer without error", func() {
 				w := &bytes.Buffer{}
 				palette := prism.SystemPalette()
 
@@ -44,7 +48,7 @@ var _ = Describe("New", func() {
 			palette := prism.SystemPalette()
 			palette.Directory = prism.SemanticColour{ANSI16: "notacolour"}
 
-			renderer, err := prism.New(prism.StreamView, palette, w)
+			renderer, err := prism.New(prism.LinearView, palette, w)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("prism.New"))

--- a/src/prism/theme.go
+++ b/src/prism/theme.go
@@ -76,7 +76,7 @@ type Theme struct {
 	// LaneHeaderStyle is applied to per-worker lane identity headers.
 	LaneHeaderStyle lipgloss.Style
 
-	// TreeIcons are the glyphs used to render the branch tree in stream
+	// TreeIcons are the glyphs used to render the branch tree in linear
 	// views such as the linear renderer.
 	TreeIcons TreeIcons
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  - Restructured renderer system with new factory pattern for extensibility
  - Consolidated linear view implementation into dedicated package
  - Updated terminology from "stream view" to "linear view"

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snivilised/jaywalk/pull/499)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->