### PR TITLE
feat(prism): render skipped count in linear view (#504)

### DIFF
--- a/src/app/bedrock/theme-loader_test.go
+++ b/src/app/bedrock/theme-loader_test.go
@@ -32,6 +32,7 @@ palette:
     root-icon: "✻"
     directory-icon: "📁"
     file-icon: "🔖"
+    skipped-icon: "⛔️"
     elapsed-icon: "⏰"
     branch-vertical: "│"
     branch-joint: "├── "
@@ -153,6 +154,7 @@ var _ = Describe("ThemeLoader", Ordered, func() {
 				Expect(palette.TreeIcons["root-icon"]).To(Equal("✻"))
 				Expect(palette.TreeIcons["directory-icon"]).To(Equal("📁"))
 				Expect(palette.TreeIcons["file-icon"]).To(Equal("🔖"))
+				Expect(palette.TreeIcons["skipped-icon"]).To(Equal("⛔️"))
 				Expect(palette.TreeIcons["elapsed-icon"]).To(Equal("⏰"))
 			})
 		})

--- a/src/app/ui/linear.go
+++ b/src/app/ui/linear.go
@@ -129,19 +129,20 @@ func (l *linear) OnSkipEvent(e *report.SkipEvent) {
 // OnComplete translates the Traversal outcome into a prism.Summary and
 // calls renderer.End to render the closing summary box. Kind is carried
 // from OnBegin so the summary labels correctly for resume traversals.
-func (l *linear) OnComplete(t *report.Traversal) {
+func (l *linear) OnComplete(traversal *report.Traversal) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	errs := []error{}
-	if t.Err != nil {
-		errs = append(errs, t.Err)
+	if traversal.Err != nil {
+		errs = append(errs, traversal.Err)
 	}
 
 	l.renderer.End(prism.Summary{
-		FilesVisited: t.FilesVisited,
-		DirsVisited:  t.DirsVisited,
-		Elapsed:      t.Elapsed,
+		FilesVisited: traversal.FilesVisited,
+		DirsVisited:  traversal.DirsVisited,
+		Skipped:      traversal.ActionsSkipped.Value(),
+		Elapsed:      traversal.Elapsed,
 		Errors:       errs,
 		Kind:         l.kind,
 	})

--- a/src/app/ui/registry_test.go
+++ b/src/app/ui/registry_test.go
@@ -63,6 +63,8 @@ var _ = Describe("Registry", func() {
 					prism.TreeIconRoot:           "*",
 					prism.TreeIconDirectory:      "D",
 					prism.TreeIconFile:           "F",
+					prism.TreeIconElapsed:        "E",
+					prism.TreeIconSkipped:        "S",
 					prism.TreeIconBranchVertical: "|",
 					prism.TreeIconBranchJoint:    "+-- ",
 					prism.TreeIconBranchLast:     "L-- ",

--- a/src/prism/flow/linear-renderer.go
+++ b/src/prism/flow/linear-renderer.go
@@ -36,13 +36,10 @@ type renderer struct {
 // Begin renders the opening banner using the Overture metadata. The banner
 // adapts to indicate prime or resume traversal.
 func (r *renderer) Begin(overture prism.Overture) {
-	var title string
-
-	if overture.Kind == prism.ResumeNavigation {
-		title = fmt.Sprintf("  jay  resuming %s", overture.Root)
-	} else {
-		title = fmt.Sprintf("  jay  %s", overture.Root)
-	}
+	title := lo.Ternary(overture.Kind == prism.ResumeNavigation,
+		fmt.Sprintf("  jay  resuming %s", overture.Root),
+		fmt.Sprintf("  jay  %s", overture.Root),
+	)
 
 	caption := fmt.Sprintf("  %s  -  %s",
 		overture.Caption,
@@ -183,10 +180,11 @@ func (r *renderer) renderActionOrPipeline(motif prism.Motif) string {
 }
 
 func (r *renderer) renderExecutionInfo(motif prism.Motif) string {
+	skipped := lo.Ternary(motif.Skipped, fmt.Sprintf(" %s", r.treeIcons[prism.TreeIconSkipped]), "")
 	if motif.DryRun {
-		return r.theme.LandingStripStyle.Render(" [" + motif.ExecutionString + "]")
+		return r.theme.LandingStripStyle.Render(" ["+skipped, motif.ExecutionString, "]")
 	} else if motif.CommandOutput != "" {
-		return r.theme.LandingStripStyle.Render(" [" + motif.CommandOutput + "]")
+		return r.theme.LandingStripStyle.Render(" ["+skipped, motif.CommandOutput, "]")
 	}
 
 	return ""
@@ -212,7 +210,10 @@ func (r *renderer) branchPrefix(motif prism.Motif) string {
 		}
 	}
 
-	branchIcon := lo.Ternary(motif.IsLast, prism.TreeIconBranchLast, prism.TreeIconBranchJoint)
+	branchIcon := lo.Ternary(motif.IsLast,
+		prism.TreeIconBranchLast,
+		prism.TreeIconBranchJoint,
+	)
 	b.WriteString(r.treeIcons[branchIcon])
 
 	return b.String()
@@ -246,6 +247,8 @@ func (r *renderer) updateBranchStack(motif prism.Motif) {
 func (r *renderer) End(summary prism.Summary) {
 	fileLabel := "Files"
 	dirLabel := "Directories"
+	skippedLabel := "Skipped"
+	elapsedLabel := "Elapsed"
 
 	if summary.Kind == prism.ResumeNavigation {
 		fileLabel = "Files (resumed)"
@@ -255,7 +258,8 @@ func (r *renderer) End(summary prism.Summary) {
 	lines := []string{
 		r.summaryRowWithIcon(prism.TreeIconFile, fileLabel, fmt.Sprintf("%d", summary.FilesVisited)),
 		r.summaryRowWithIcon(prism.TreeIconDirectory, dirLabel, fmt.Sprintf("%d", summary.DirsVisited)),
-		r.summaryRowWithIcon(prism.TreeIconElapsed, "Elapsed", core.FormatDuration(summary.Elapsed)),
+		r.summaryRowWithIcon(prism.TreeIconSkipped, skippedLabel, fmt.Sprintf("%d", summary.Skipped)),
+		r.summaryRowWithIcon(prism.TreeIconElapsed, elapsedLabel, core.FormatDuration(summary.Elapsed)),
 	}
 
 	if len(summary.Errors) > 0 {
@@ -278,6 +282,10 @@ func (r *renderer) End(summary prism.Summary) {
 	_, _ = lipgloss.Fprintln(r.writer, box)
 }
 
+func (r *renderer) summaryRow(label, value string) string {
+	return r.summaryRowWithIcon("", label, value)
+}
+
 func (r *renderer) summaryRowWithIcon(iconKey, label, value string) string {
 	icon := r.treeIcons[iconKey]
 	if icon != "" {
@@ -286,8 +294,4 @@ func (r *renderer) summaryRowWithIcon(iconKey, label, value string) string {
 
 	return r.theme.SummaryLabelStyle.Render(label) +
 		r.theme.SummaryValueStyle.Render(value)
-}
-
-func (r *renderer) summaryRow(label, value string) string {
-	return r.summaryRowWithIcon("", label, value)
 }

--- a/src/prism/palette.go
+++ b/src/prism/palette.go
@@ -109,6 +109,7 @@ const (
 	TreeIconDirectory      = "directory-icon"
 	TreeIconFile           = "file-icon"
 	TreeIconElapsed        = "elapsed-icon"
+	TreeIconSkipped        = "skipped-icon"
 	TreeIconBranchVertical = "branch-vertical"
 	TreeIconBranchJoint    = "branch-joint"
 	TreeIconBranchLast     = "branch-last"

--- a/src/prism/prism.go
+++ b/src/prism/prism.go
@@ -158,6 +158,9 @@ type Summary struct {
 	// DirsVisited is the count of directories encountered.
 	DirsVisited core.MetricValue
 
+	// Skipped is the count of nodes for which actions were skipped.
+	Skipped core.MetricValue
+
 	// Elapsed is the total duration of the traversal.
 	Elapsed time.Duration
 

--- a/src/prism/theme.go
+++ b/src/prism/theme.go
@@ -14,6 +14,7 @@ func defaultTreeIcons() TreeIcons {
 		TreeIconDirectory:      "📁",
 		TreeIconFile:           "🔖",
 		TreeIconElapsed:        "⏰",
+		TreeIconSkipped:        "⛔️",
 		TreeIconBranchVertical: "│",
 		TreeIconBranchJoint:    "├── ",
 		TreeIconBranchLast:     "└── ",

--- a/test/data/rounded-tree.theme.yml
+++ b/test/data/rounded-tree.theme.yml
@@ -125,6 +125,7 @@ tree-icons:
   directory-icon: "📁"
   file-icon: "🔖"
   elapsed-icon: "⏰"
+  skipped-icon: "⛔️"
   branch-vertical: "│"
   branch-joint: "├── "
   branch-last: "╰── "

--- a/test/data/square-tree.theme.yml
+++ b/test/data/square-tree.theme.yml
@@ -125,6 +125,7 @@ tree-icons:
   directory-icon: "📁"
   file-icon: "🔖"
   elapsed-icon: "⏰"
+  skipped-icon: "⛔️"
   branch-vertical: "│"
   branch-joint: "├── "
   branch-last: "└── "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skipped count metric to execution summaries for tracking skipped actions
  * Introduced dedicated skipped-icon support in theme customization (default: ⛔️)

* **Tests**
  * Extended test coverage to validate skipped-icon theme configuration and rendering

* **Theme Configuration**
  * Updated default theme files to include skipped-icon palette entry

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snivilised/jaywalk/pull/505)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->