### PR TITLE
fix: opencode docker container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -48,5 +48,6 @@ ENV HOME=/home/opencode
 # The project code from the host is mounted here at runtime.
 WORKDIR /workspace
 
-# Every time the container starts it launches opencode's TUI.
-ENTRYPOINT ["opencode"]
+# Dev container stays alive so you can exec in.
+# Run `opencode` manually via `docker exec -it the-orville opencode`.
+CMD ["sleep", "infinity"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   opencode:
+    container_name: the-orville
     build:
       context: .
       dockerfile: Dockerfile.dev


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development container startup behavior updated: TUI no longer auto-launches; container now persists in background, awaiting manual invocation.
  * Development service container assigned an explicit, static name for consistent Docker references and easier container management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snivilised/jaywalk/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->