### PR TITLE
fix:(controller): ensure ctrl-c interrupt handled in sprint (#539)

### DIFF
--- a/src/agenor/internal/kernel/navigator-async_test.go
+++ b/src/agenor/internal/kernel/navigator-async_test.go
@@ -2,6 +2,7 @@ package kernel_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -262,4 +263,69 @@ var _ = Describe("Navigator", Ordered, func() {
 			Consume: true,
 		}, SpecTimeout(time.Second*2)),
 	)
+})
+
+var _ = Describe("Navigator cancellation", func() {
+	var fS *luna.MemFS
+
+	BeforeEach(func() {
+		Expect(li18ngo.Register(
+			func(o *li18ngo.UseOptions) {
+				o.From.Sources = li18ngo.TranslationFiles{
+					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},
+				}
+			},
+		)).To(Succeed())
+		services.Reset()
+		fS = hanno.Nuxx(verbose, lab.Static.RetroWave)
+	})
+
+	It("should return saved error when context is cancelled mid-sprint", SpecTimeout(time.Second*2), func(specCtx SpecContext) {
+		lab.WithTestContext(specCtx, func(ctx context.Context, cancel context.CancelFunc) {
+			var wg sync.WaitGroup
+
+			navCtx, navCancel := context.WithCancel(ctx)
+			defer navCancel()
+
+			cancelled := false
+			callback := func(servant core.Servant) error {
+				if !cancelled {
+					cancelled = true
+					navCancel()
+				}
+				return nil
+			}
+
+			result, err := agenor.Sprint(&wg).Configure(
+				enclave.Loader(func(active *core.ActiveState) {
+					active.Tree = lab.Static.RetroWave
+					active.Subscription = enums.SubscribeUniversal
+				}),
+			).Extent(
+				agenor.Prime(
+					&pref.Using{
+						Tree:         lab.Static.RetroWave,
+						Subscription: enums.SubscribeUniversal,
+						Head: pref.Head{
+							Handler: callback,
+							GetForest: func(_ string) *core.Forest {
+								return &core.Forest{
+									T: fS,
+									R: tfs.New(),
+								}
+							},
+						},
+					},
+					agenor.WithNoW(3),
+				),
+			).Navigate(navCtx)
+
+			wg.Wait()
+
+			Expect(err).To(HaveOccurred())
+			var savedErr *locale.TraversalSavedError
+			Expect(errors.As(err, &savedErr)).To(BeTrue())
+			Expect(result).NotTo(BeNil())
+		})
+	})
 })

--- a/src/app/controller/coordinator.go
+++ b/src/app/controller/coordinator.go
@@ -292,6 +292,7 @@ func (c *Coordinator) execute(
 		ActionName:   req.ActionName,
 		PipelineName: req.PipelineName,
 		DateFormat:   c.config.Mapped.Interaction.DateFormat,
+		Cancel:       cancel,
 	})
 
 	result, err := req.Scenario(facade, req.Settings...).Navigate(ctx)
@@ -359,7 +360,9 @@ func (c *Coordinator) useShellPoolExec(
 	pool := newShellPoolExecutor(manifold)
 
 	previousExec := c.exec
-	c.exec = pool.Execute
+	c.exec = func(_ context.Context, command string) ([]byte, error) {
+		return pool.Execute(ctx, command)
+	}
 
 	return func() {
 		c.exec = previousExec

--- a/src/app/controller/dispatch_test.go
+++ b/src/app/controller/dispatch_test.go
@@ -1,11 +1,13 @@
 package controller
 
 import (
+	"context"
 	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/app/bedrock"
 )
 
@@ -64,5 +66,41 @@ var _ = Describe("Dispatch Output Processing", func() {
 			Expect(result).To(Equal("this is a very long line that should be truncated normally, but let us  ..."))
 			Expect(len(result)).To(Equal(75))
 		})
+	})
+})
+
+var _ = Describe("executeAction", func() {
+	It("propagates context cancellation from exec", func() {
+		cfg := &bedrock.Config{}
+		cfg.Raw.Actions = map[string]bedrock.RawAction{
+			"test-action": {Cmd: "echo hello"},
+		}
+		c := &Coordinator{
+			config: cfg,
+			exec: func(_ context.Context, _ string) ([]byte, error) {
+				return nil, context.Canceled
+			},
+		}
+
+		node := core.New("test-path", nil, nil, nil, nil)
+		result := c.executeAction(context.Background(), node, "test-action", "", false)
+		Expect(result.Event.Err).To(MatchError(context.Canceled))
+	})
+
+	It("returns nil error when exec succeeds", func() {
+		cfg := &bedrock.Config{}
+		cfg.Raw.Actions = map[string]bedrock.RawAction{
+			"test-action": {Cmd: "echo hello"},
+		}
+		c := &Coordinator{
+			config: cfg,
+			exec: func(_ context.Context, _ string) ([]byte, error) {
+				return []byte("ok"), nil
+			},
+		}
+
+		node := core.New("test-path", nil, nil, nil, nil)
+		result := c.executeAction(context.Background(), node, "test-action", "", false)
+		Expect(result.Event.Err).To(BeNil())
 	})
 })

--- a/src/app/report/report-defs.go
+++ b/src/app/report/report-defs.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"context"
 	"time"
 
 	"github.com/snivilised/jaywalk/src/agenor/core"
@@ -51,6 +52,11 @@ type BeginEvent struct {
 	// DateFormat is the Go time format string for rendering StartedAt
 	// in the view header. Empty means use the default (time.RFC1123).
 	DateFormat string
+
+	// Cancel is the context cancellation function for the traversal.
+	// When set, the presenter may call Cancel to abort the traversal
+	// (e.g., in response to a user interrupt like Ctrl-C in the TUI).
+	Cancel context.CancelFunc
 }
 
 // NeutralEvent is emitted per node visit when no action or pipeline is

--- a/src/app/ui/highway.go
+++ b/src/app/ui/highway.go
@@ -101,6 +101,16 @@ func (h *highwayPresenter) OnBegin(e *report.BeginEvent) {
 		close(h.done)
 	}()
 
+	// Monitor for premature bubbletea exit (e.g., user pressed Ctrl-C).
+	// When the program exits before OnComplete is called, cancel the
+	// traversal context so the navigator stops and saves resume state.
+	if e.Cancel != nil {
+		go func() {
+			<-h.done
+			e.Cancel()
+		}()
+	}
+
 	h.program.Send(highway.OvertureMsg{
 		Root:              e.Root,
 		Caption:           e.Caption,

--- a/src/prism/traffic/highway/model.go
+++ b/src/prism/traffic/highway/model.go
@@ -98,7 +98,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		if m.done && msg.String() == "space" {
+		switch {
+		case m.done && msg.String() == "space":
+			return m, tea.Quit
+		case msg.String() == "ctrl+c":
 			return m, tea.Quit
 		}
 		return m, nil

--- a/src/prism/traffic/highway/model_test.go
+++ b/src/prism/traffic/highway/model_test.go
@@ -170,6 +170,19 @@ var _ = Describe("Model.Update — KeyMsg", func() {
 		_, cmd := update(m, tea.KeyPressMsg{})
 		Expect(cmd).To(BeNil())
 	})
+
+	It("returns tea.Quit on ctrl+c before done", func() {
+		m := baseModel(1)
+		_, cmd := update(m, tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+		Expect(cmd).NotTo(BeNil())
+	})
+
+	It("returns tea.Quit on ctrl+c after done", func() {
+		m := baseModel(1)
+		m.done = true
+		_, cmd := update(m, tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+		Expect(cmd).NotTo(BeNil())
+	})
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cancellation support for in-progress traversal operations via UI interaction.
  * Presenters can now trigger traversal abort through UI controls.

* **Improvements**
  * Enhanced keyboard input handling for application exit during traversal operations.

* **Tests**
  * Added test coverage for traversal cancellation behavior.
  * Added test coverage for action execution error propagation.
  * Added test coverage for keyboard interrupt handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snivilised/jaywalk/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->