### PR TITLE
feat(prism): add flags row to highway view (#568)

### DIFF
--- a/src/agenor/core/filtering.go
+++ b/src/agenor/core/filtering.go
@@ -155,3 +155,12 @@ var BenignNodeFilterDef = FilterDef{
 	Pattern:     ".",
 	Scope:       enums.ScopeTree,
 }
+
+// IsBenign reports whether the filter is the BenignNodeFilterDef (the
+// "allow everything" default used as a placeholder when the user has
+// not supplied a filter of the relevant kind). The display layer uses
+// this to distinguish a user-specified filter from a placeholder that
+// happens to be active because the user only set the other one.
+func (f FilterDef) IsBenign() bool {
+	return f == BenignNodeFilterDef
+}

--- a/src/app/bedrock/data/example.jay.ui.yml
+++ b/src/app/bedrock/data/example.jay.ui.yml
@@ -23,6 +23,12 @@ ui:
     # Character between emoji and content info (default: single space)
     separator: ' '
 
+    # Position of the supplementary flags row within the highway view.
+    # Allowed: 'top' (after the top border, before the first lane) or
+    # 'bottom' (above the status line, below the last lane). Defaults to
+    # 'bottom' when omitted or set to an unrecognised value.
+    flags-row-position: 'bottom'
+
     # Animation data configuration for Highway view lanes
     animation:
       # List of animation types to load on demand

--- a/src/app/bedrock/types.go
+++ b/src/app/bedrock/types.go
@@ -146,6 +146,13 @@ type HighwayConfig struct {
 	// Must match a key in palette.highlights.gradients (e.g., "aurora-borealis").
 	// When empty, no gradient is applied and default styling is used.
 	AnimationGradient string `mapstructure:"animation-gradient,omitempty"`
+
+	// FlagsRowPosition controls where the supplementary flags row is rendered
+	// within the highway view. Allowed values: "top" (between the top border
+	// and the first lane) or "bottom" (between the last lane and the status
+	// line). Empty or invalid values default to "bottom" and a warning is
+	// logged at load time.
+	FlagsRowPosition string `mapstructure:"flags-row-position,omitempty"`
 }
 
 // HighwayAnimationConfig holds animation data configuration for Highway view.

--- a/src/app/command/settings.go
+++ b/src/app/command/settings.go
@@ -10,20 +10,47 @@ import (
 	"github.com/snivilised/jaywalk/src/locale"
 )
 
+// Poly filter flag names (must match the first token of the i18n
+// usage text used to bind them in store.PolyFilterParameterSet).
+const (
+	polyFlagFiles      = "files"
+	polyFlagFilesRegex = "files-regex"
+	polyFlagDirsGlob   = "dirs-glob"
+	polyFlagDirsRegex  = "dirs-regex"
+)
+
+// createTraversalSettingsIntent builds a TraversalSettingsIntent from the
+// nav families. Poly filter fields are populated only when the user
+// actually set the corresponding flag on the command line (detected via
+// cobra's Flags().Changed), so an empty string in the resulting
+// FilterIntent reliably means "user did not specify this filter" -
+// independent of any default values the flag may carry.
 func createTraversalSettingsIntent(families NavFamilies) controller.TraversalSettingsIntent {
-	return controller.TraversalSettingsIntent{
+	intent := controller.TraversalSettingsIntent{
 		NoRecurse:     families.Cascade.Native.NoRecurse,
 		Depth:         core.TraversalDepth(families.Cascade.Native.Depth),
 		IsSampling:    families.Sampling.Native.IsSampling,
 		NoFiles:       families.Sampling.Native.NoFiles,
 		NoDirectories: families.Sampling.Native.NoDirectories,
-		Filter: controller.FilterIntent{
-			FilesExGlob:      families.PolyFam.Native.FilesExGlob,
-			FilesRegEx:       families.PolyFam.Native.FilesRegEx,
-			DirectoriesGlob:  families.PolyFam.Native.DirectoriesGlob,
-			DirectoriesRegEx: families.PolyFam.Native.DirectoriesRegEx,
-		},
 	}
+
+	flags := families.PolyFam.Command.Flags()
+	native := families.PolyFam.Native
+
+	if flags.Changed(polyFlagFiles) {
+		intent.Filter.FilesExGlob = native.FilesExGlob
+	}
+	if flags.Changed(polyFlagFilesRegex) {
+		intent.Filter.FilesRegEx = native.FilesRegEx
+	}
+	if flags.Changed(polyFlagDirsGlob) {
+		intent.Filter.DirectoriesGlob = native.DirectoriesGlob
+	}
+	if flags.Changed(polyFlagDirsRegex) {
+		intent.Filter.DirectoriesRegEx = native.DirectoriesRegEx
+	}
+
+	return intent
 }
 
 // resolveResumeStrategy maps the --resume flag string to the agenor constant.

--- a/src/app/command/settings_test.go
+++ b/src/app/command/settings_test.go
@@ -1,0 +1,156 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/mamba/assist"
+	"github.com/snivilised/mamba/store"
+	"github.com/snivilised/li18ngo"
+
+	"github.com/snivilised/jaywalk/src/locale"
+)
+
+// buildTestNavFamilies constructs a fully populated navState bound to a
+// real cobra command. Cascade/sampling/poly are bound; nav and preview
+// are stubbed nil since createTraversalSettingsIntent only reads from
+// cascade, sampling and poly.
+func buildTestNavFamilies() (*cobra.Command, *navState) {
+	cmd := &cobra.Command{Use: "test"}
+	_ = assist.NewParamSet[NavParameterSet](cmd)
+	_ = assist.NewParamSet[store.PreviewParameterSet](cmd)
+	cascadePs := assist.NewParamSet[store.CascadeParameterSet](cmd)
+	cascadePs.Native.BindAll(cascadePs, cmd.Flags())
+	samplingPs := assist.NewParamSet[store.SamplingParameterSet](cmd)
+	samplingPs.Native.BindAll(samplingPs, cmd.Flags())
+	polyPs := assist.NewParamSet[store.PolyFilterParameterSet](cmd)
+	polyPs.Native.BindAll(polyPs, cmd.Flags())
+	return cmd, &navState{
+		cascadeFam:  cascadePs,
+		samplingFam: samplingPs,
+		polyFam:     polyPs,
+	}
+}
+
+func init() {
+	// mamba's BindAll invokes li18ngo.Text(...) for each flag's
+	// usage string; without registration the call panics. We only
+	// need the bare Register() here because the test never asserts
+	// on rendered flag text.
+	_ = li18ngo.Register(
+		func(o *li18ngo.UseOptions) {
+			o.From.Sources = li18ngo.TranslationFiles{
+				locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},
+			}
+		},
+	)
+}
+
+var _ = Describe("createTraversalSettingsIntent (poly filter Changed detection)", func() {
+	It("leaves filter fields empty when no poly flags are set", func() {
+		cmd, ns := buildTestNavFamilies()
+
+		cmd.SetArgs([]string{})
+		_, err := cmd.ExecuteC()
+		Expect(err).NotTo(HaveOccurred())
+
+		intent := createTraversalSettingsIntent(navFamilies(ns))
+		Expect(intent.Filter.FilesExGlob).To(BeEmpty())
+		Expect(intent.Filter.FilesRegEx).To(BeEmpty())
+		Expect(intent.Filter.DirectoriesGlob).To(BeEmpty())
+		Expect(intent.Filter.DirectoriesRegEx).To(BeEmpty())
+	})
+
+	It("captures the --files value when set", func() {
+		cmd, ns := buildTestNavFamilies()
+
+		cmd.SetArgs([]string{"--files", "*|.go"})
+		_, err := cmd.ExecuteC()
+		Expect(err).NotTo(HaveOccurred())
+
+		intent := createTraversalSettingsIntent(navFamilies(ns))
+		Expect(intent.Filter.FilesExGlob).To(Equal("*|.go"))
+		Expect(intent.Filter.FilesRegEx).To(BeEmpty())
+		Expect(intent.Filter.DirectoriesGlob).To(BeEmpty())
+		Expect(intent.Filter.DirectoriesRegEx).To(BeEmpty())
+	})
+
+	It("captures --files-regex when set", func() {
+		cmd, ns := buildTestNavFamilies()
+
+		cmd.SetArgs([]string{"--files-regex", `^_`})
+		_, err := cmd.ExecuteC()
+		Expect(err).NotTo(HaveOccurred())
+
+		intent := createTraversalSettingsIntent(navFamilies(ns))
+		Expect(intent.Filter.FilesRegEx).To(Equal("^_"))
+		Expect(intent.Filter.FilesExGlob).To(BeEmpty())
+	})
+
+	It("captures --dirs-glob when set", func() {
+		cmd, ns := buildTestNavFamilies()
+
+		cmd.SetArgs([]string{"--dirs-glob", "vendor"})
+		_, err := cmd.ExecuteC()
+		Expect(err).NotTo(HaveOccurred())
+
+		intent := createTraversalSettingsIntent(navFamilies(ns))
+		Expect(intent.Filter.DirectoriesGlob).To(Equal("vendor"))
+		Expect(intent.Filter.DirectoriesRegEx).To(BeEmpty())
+	})
+
+	It("captures --dirs-regex when set", func() {
+		cmd, ns := buildTestNavFamilies()
+
+		cmd.SetArgs([]string{"--dirs-regex", `^\.`})
+		_, err := cmd.ExecuteC()
+		Expect(err).NotTo(HaveOccurred())
+
+		intent := createTraversalSettingsIntent(navFamilies(ns))
+		Expect(intent.Filter.DirectoriesRegEx).To(Equal(`^\.`))
+		Expect(intent.Filter.DirectoriesGlob).To(BeEmpty())
+	})
+
+	It("captures multiple flags when several are set", func() {
+		cmd, ns := buildTestNavFamilies()
+
+		cmd.SetArgs([]string{
+			"--files", "*|.go",
+			"--dirs-regex", `^\.`,
+		})
+		_, err := cmd.ExecuteC()
+		Expect(err).NotTo(HaveOccurred())
+
+		intent := createTraversalSettingsIntent(navFamilies(ns))
+		Expect(intent.Filter.FilesExGlob).To(Equal("*|.go"))
+		Expect(intent.Filter.DirectoriesRegEx).To(Equal(`^\.`))
+		Expect(intent.Filter.FilesRegEx).To(BeEmpty())
+		Expect(intent.Filter.DirectoriesGlob).To(BeEmpty())
+	})
+
+	// regression: even if a flag has a non-empty default value, an
+	// un-set flag must yield an empty FilterIntent field, so the
+	// BenignNodeFilterDef placeholder is correctly distinguished
+	// from a user-supplied filter.
+	It("treats an un-set flag with a non-empty default as empty in the intent", func() {
+		cmd, ns := buildTestNavFamilies()
+
+		// Manually override the default value of the "files" flag to
+		// a non-empty string, simulating a future where this flag
+		// carries a default. The user's command line did NOT set it.
+		flag := cmd.Flags().Lookup(polyFlagFiles)
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Value.Set("non-empty-default")).To(Succeed())
+		// Important: do NOT mark it as changed.
+
+		cmd.SetArgs([]string{})
+		_, err := cmd.ExecuteC()
+		Expect(err).NotTo(HaveOccurred())
+
+		intent := createTraversalSettingsIntent(navFamilies(ns))
+		Expect(intent.Filter.FilesExGlob).To(BeEmpty(),
+			"un-set flag with non-empty default must NOT populate the intent")
+	})
+})

--- a/src/app/controller/coordinator.go
+++ b/src/app/controller/coordinator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/snivilised/jaywalk/src/app/bedrock"
 	"github.com/snivilised/jaywalk/src/app/report"
 	"github.com/snivilised/jaywalk/src/app/shell"
+	"github.com/snivilised/jaywalk/src/prism/contract"
 )
 
 // Coordinator coordinates the layers between the command adapters and
@@ -283,8 +284,7 @@ func (c *Coordinator) execute(
 	defer closeExec()
 
 	// Extract header info before creating BeginEvent for consistency with highway model
-	cascadeDisplay, filesGlob, filesRegex, dirsGlob, dirsRegex, fileTypeMode, dirTypeMode :=
-		extractHeaderInfo(req)
+	headerInfo := extractHeaderInfo(req)
 
 	req.UI.OnBegin(&report.BeginEvent{
 		Root:         req.Root,
@@ -298,14 +298,12 @@ func (c *Coordinator) execute(
 		DateFormat:   c.config.Mapped.Interaction.DateFormat,
 		Cancel:       cancel,
 
-		// Header info fields
-		CascadeDisplay: cascadeDisplay,
-		FilesGlob:      filesGlob,
-		FilesRegex:     filesRegex,
-		DirsGlob:       dirsGlob,
-		DirsRegex:      dirsRegex,
-		FileTypeMode:   fileTypeMode,
-		DirTypeMode:    dirTypeMode,
+		// Header info: supplementary flag values extracted from
+		// resolved traversal options for display in the highway view.
+		Header: headerInfo,
+
+		// Position of the flags row within the highway view
+		FlagsRowPosition: c.config.Mapped.Highway.FlagsRowPosition,
 	})
 
 	result, err := req.Scenario(facade, req.Settings...).Navigate(ctx)
@@ -383,10 +381,14 @@ func (c *Coordinator) useShellPoolExec(
 	}, nil
 }
 
-// extractHeaderInfo extracts cascade display (padlock or depth) and filter flag info from the Options
-// that were passed through BuildTraversalSettings. This preserves display information
-// even though the pref.Options struct doesn't directly expose the original flags.
-func extractHeaderInfo(req *Request) (cascade, filesGlob, filesRegex, dirsGlob, dirsRegex string, fileType, dirType string) {
+// extractHeaderInfo extracts cascade display (padlock or depth), filter
+// flag info and sampler info from the Options that were passed through
+// BuildTraversalSettings. This preserves display information even
+// though the pref.Options struct doesn't directly expose the original
+// flags. The returned HeaderInfo is then embedded in the BeginEvent
+// sent to the UI presenter (see contract.HeaderInfo for field semantics).
+func extractHeaderInfo(req *Request) contract.HeaderInfo {
+	var info contract.HeaderInfo
 	options := &pref.Options{}
 
 	// Extract options from settings by running all option functions
@@ -395,15 +397,15 @@ func extractHeaderInfo(req *Request) (cascade, filesGlob, filesRegex, dirsGlob, 
 			continue
 		}
 		if err := setting(options); err != nil {
-			return "", "", "", "", "", "", "" // error case - return empty
+			return contract.HeaderInfo{} // error case - return empty
 		}
 	}
 
 	// Extract cascade display (no-recurse or depth) from behaviours
 	if options.Behaviours.Cascade.NoRecurse {
-		cascade = "🔒"
+		info.CascadeDisplay = "🔒"
 	} else if options.Behaviours.Cascade.Depth > 0 {
-		cascade = fmt.Sprintf("depth:%d", options.Behaviours.Cascade.Depth)
+		info.CascadeDisplay = fmt.Sprintf("depth:%d", options.Behaviours.Cascade.Depth)
 	}
 
 	// Extract filter info from poly filter definitions
@@ -411,35 +413,77 @@ func extractHeaderInfo(req *Request) (cascade, filesGlob, filesRegex, dirsGlob, 
 		fileDef := options.Filter.Node.Poly.File
 		dirDef := options.Filter.Node.Poly.Directory
 
+		// TranslateFilterIntent places BenignNodeFilterDef into the slot
+		// the user did not specify (e.g. when the user only sets
+		// --files, the directory slot is filled with the benign default
+		// "match anything" filter). We must skip those placeholders here
+		// so they don't appear in the flags row as if the user had
+		// specified them (e.g. "dirs regex: .").
+		fileActive := !fileDef.IsBenign() && fileDef.Pattern != ""
+		dirActive := !dirDef.IsBenign() && dirDef.Pattern != ""
+
 		// Determine file pattern and type
-		if fileDef.Type == enums.FilterTypeGlobEx && fileDef.Pattern != "" {
-			filesGlob = fileDef.Pattern
-		} else if fileDef.Type == enums.FilterTypeRegex && fileDef.Pattern != "" {
-			filesRegex = fileDef.Pattern
+		if fileActive {
+			//nolint:staticcheck // QF1003: if/else chain intentionally
+			// avoids a switch because the `exhaustive` linter requires
+			// every FilterType enum value to be listed.
+			if fileDef.Type == enums.FilterTypeGlobEx {
+				info.FilesGlob = fileDef.Pattern
+			} else if fileDef.Type == enums.FilterTypeRegex {
+				info.FilesRegex = fileDef.Pattern
+			}
 		}
 
 		// Determine directory pattern and type
-		if dirDef.Type == enums.FilterTypeGlob && dirDef.Pattern != "" {
-			dirsGlob = dirDef.Pattern
-		} else if dirDef.Type == enums.FilterTypeRegex && dirDef.Pattern != "" {
-			dirsRegex = dirDef.Pattern
+		if dirActive {
+			//nolint:staticcheck // QF1003: see comment above.
+			if dirDef.Type == enums.FilterTypeGlob {
+				info.DirsGlob = dirDef.Pattern
+			} else if dirDef.Type == enums.FilterTypeRegex {
+				info.DirsRegex = dirDef.Pattern
+			}
 		}
 
-		// Determine filter types based on precedence (regex takes priority when both exist)
-		fileType = determineFileType(fileDef.Type, fileDef.Pattern != "")
-		dirType = determineFileType(dirDef.Type, dirDef.Pattern != "")
+		// Determine filter types based on precedence (regex takes priority
+		// when both exist). Defaults to "glob" when the slot is benign
+		// (no user-specified filter).
+		if fileActive {
+			info.FileTypeMode = determineFileType(fileDef.Type)
+		} else {
+			info.FileTypeMode = filterModeGlob
+		}
+		if dirActive {
+			info.DirTypeMode = determineFileType(dirDef.Type)
+		} else {
+			info.DirTypeMode = filterModeGlob
+		}
 	}
 
-	return cascade, filesGlob, filesRegex, dirsGlob, dirsRegex, fileType, dirType
+	// Extract sampler info (only meaningful when sampling is active)
+	if options.Sampling.IsSamplingActive() {
+		info.NumFiles = options.Sampling.NoOf.Files
+		info.NumFolders = options.Sampling.NoOf.Directories
+		info.SampleLast = options.Sampling.InReverse
+	}
+
+	return info
 }
 
-// determineFileType returns "regex" if pattern is a regex, otherwise "glob".
-// This helps distinguish display format but defaults to glob for backwards compatibility.
-func determineFileType(filterType enums.FilterType, hasPattern bool) string {
-	if filterType == enums.FilterTypeRegex && hasPattern {
-		return "regex"
+// filter mode labels used by HeaderInfo.FileTypeMode / HeaderInfo.DirTypeMode
+const (
+	filterModeGlob  = "glob"
+	filterModeRegex = "regex"
+)
+
+// determineFileType returns "regex" if the filter is a regex type,
+// otherwise "glob". The caller must have already established that the
+// filter is user-supplied and not the benign default; this helper only
+// inspects the type.
+func determineFileType(filterType enums.FilterType) string {
+	if filterType == enums.FilterTypeRegex {
+		return filterModeRegex
 	}
-	return "glob" // default
+	return filterModeGlob
 }
 func (c *Coordinator) captionFor(req *Request) string {
 	subscription := ""

--- a/src/app/controller/header-info_test.go
+++ b/src/app/controller/header-info_test.go
@@ -1,0 +1,99 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/jaywalk/src/agenor"
+	"github.com/snivilised/jaywalk/src/agenor/core"
+	"github.com/snivilised/jaywalk/src/agenor/enums"
+	"github.com/snivilised/jaywalk/src/agenor/pref"
+)
+
+// extractHeaderInfo is exercised indirectly via Coordinator.coordinate
+// at runtime. These specs invoke it directly to verify the benign
+// default filter placeholder does not surface in the flags row as a
+// user-supplied filter (the bug that caused "dirs regex: ." to appear
+// even when the user had not specified --dirs-regex).
+var _ = Describe("extractHeaderInfo", func() {
+	buildRequest := func(settings ...pref.Option) *Request {
+		return &Request{
+			Settings: settings,
+		}
+	}
+
+	It("ignores the benign default in the file slot when only --dirs-regex is set", func() {
+		req := buildRequest(pref.WithFilter(&pref.FilterOptions{
+			Node: &core.FilterDef{
+				Type: enums.FilterTypePoly,
+				Poly: &core.PolyFilterDef{
+					File:      core.BenignNodeFilterDef, // placeholder
+					Directory: core.FilterDef{
+						Type:        enums.FilterTypeRegex,
+						Pattern:     "src/.*",
+						Description: "dirs-regex:src/.*",
+					},
+				},
+			},
+		}))
+
+		got := extractHeaderInfo(req)
+		Expect(got.FilesGlob).To(BeEmpty())
+		Expect(got.FilesRegex).To(BeEmpty())
+		Expect(got.DirsRegex).To(Equal("src/.*"))
+		Expect(got.DirsGlob).To(BeEmpty())
+	})
+
+	It("ignores the benign default in the directory slot when only --files is set", func() {
+		req := buildRequest(pref.WithFilter(&pref.FilterOptions{
+			Node: &core.FilterDef{
+				Type: enums.FilterTypePoly,
+				Poly: &core.PolyFilterDef{
+					File: core.FilterDef{
+						Type:        enums.FilterTypeGlobEx,
+						Pattern:     "*|.go",
+						Description: "files-glob:*|.go",
+					},
+					Directory: core.BenignNodeFilterDef, // placeholder
+				},
+			},
+		}))
+
+		got := extractHeaderInfo(req)
+		Expect(got.FilesGlob).To(Equal("*|.go"))
+		Expect(got.FilesRegex).To(BeEmpty())
+		Expect(got.DirsRegex).To(BeEmpty(),
+			"the benign '.' regex must not surface as a user flag")
+		Expect(got.DirsGlob).To(BeEmpty())
+	})
+
+	It("surfaces both filters when both are user-supplied", func() {
+		req := buildRequest(pref.WithFilter(&pref.FilterOptions{
+			Node: &core.FilterDef{
+				Type: enums.FilterTypePoly,
+				Poly: &core.PolyFilterDef{
+					File: core.FilterDef{
+						Type:        enums.FilterTypeGlobEx,
+						Pattern:     "*|.go",
+						Description: "files-glob:*|.go",
+					},
+					Directory: core.FilterDef{
+						Type:        enums.FilterTypeRegex,
+						Pattern:     "^\\.",
+						Description: "dirs-regex:^\\.",
+					},
+				},
+			},
+		}))
+
+		got := extractHeaderInfo(req)
+		Expect(got.FilesGlob).To(Equal("*|.go"))
+		Expect(got.DirsRegex).To(Equal("^\\."))
+	})
+
+	It("surfaces the cascade display when --no-recurse is set", func() {
+		req := buildRequest(agenor.WithNoRecurse())
+		got := extractHeaderInfo(req)
+		Expect(got.CascadeDisplay).To(Equal("🔒"))
+	})
+})

--- a/src/app/report/report-defs.go
+++ b/src/app/report/report-defs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
+	"github.com/snivilised/jaywalk/src/prism/contract"
 )
 
 // DisplayEvent is the base event embedded into all UI events. It carries
@@ -58,14 +59,16 @@ type BeginEvent struct {
 	// (e.g., in response to a user interrupt like Ctrl-C in the TUI).
 	Cancel context.CancelFunc
 
-	// Header display fields for filter flags
-	CascadeDisplay string // "🔒", "depth:<n>", or empty
-	FilesGlob      string // Pattern when --files-glob or -f used
-	FilesRegex     string // Pattern when --files-regex used
-	DirsGlob       string // Pattern when --dirs-glob used
-	DirsRegex      string // Pattern when --dirs-regex used
-	FileTypeMode   string // "glob" or "regex" for files
-	DirTypeMode    string // "glob" or "regex" for dirs
+	// Header groups the supplementary flag values extracted from the
+	// resolved traversal options for display in the highway view's
+	// header and flags row. See contract.HeaderInfo for the field
+	// semantics.
+	Header contract.HeaderInfo
+
+	// FlagsRowPosition selects the position of the supplementary flags
+	// row within the highway view ("top" or "bottom"). An empty or
+	// invalid value is normalised to "bottom" before the event is sent.
+	FlagsRowPosition string
 }
 
 // NeutralEvent is emitted per node visit when no action or pipeline is

--- a/src/app/ui/flags-row_test.go
+++ b/src/app/ui/flags-row_test.go
@@ -1,0 +1,126 @@
+package ui
+
+import (
+	"os"
+	"testing/fstest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/snivilised/nefilim/test/luna"
+
+	"github.com/snivilised/jaywalk/src/app/bedrock"
+	"github.com/snivilised/jaywalk/src/prism/contract"
+)
+
+var _ = Describe("normaliseFlagsRowPosition", func() {
+	It("returns the default for an empty string", func() {
+		Expect(normaliseFlagsRowPosition("")).To(Equal(FlagsRowPositionBottom))
+	})
+
+	It("returns top unchanged", func() {
+		Expect(normaliseFlagsRowPosition(FlagsRowPositionTop)).To(Equal(FlagsRowPositionTop))
+	})
+
+	It("returns bottom unchanged", func() {
+		Expect(normaliseFlagsRowPosition(FlagsRowPositionBottom)).To(Equal(FlagsRowPositionBottom))
+	})
+
+	It("returns the default and writes a warning for an unrecognised value", func() {
+		// Capture stderr for the duration of the call. Using t.TempDir
+		// isn't available here (this is a Ginkgo test), so we manually
+		// manage the temp dir.
+		tmpDir, err := os.MkdirTemp("", "flags-row-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		originalStderr := os.Stderr
+		r, w, pipeErr := os.Pipe()
+		Expect(pipeErr).NotTo(HaveOccurred())
+		os.Stderr = w
+		defer func() { os.Stderr = originalStderr }()
+
+		got := normaliseFlagsRowPosition("sideways")
+		_ = w.Close()
+		buf := make([]byte, 1024)
+		n, _ := r.Read(buf)
+		Expect(got).To(Equal(FlagsRowPositionBottom))
+		Expect(string(buf[:n])).To(ContainSubstring("sideways"))
+		Expect(string(buf[:n])).To(ContainSubstring("defaulting"))
+	})
+})
+
+var _ = Describe("loadHighwayConfig (FlagsRowPosition plumbing)", func() {
+	const configHome = "root/config"
+
+	Context("when flags-row-position is set in jay.ui.yml", func() {
+		It("propagates the value to the ui.HighwayConfig", func() {
+			fS := luna.NewMemFS()
+			fS.MapFS[configHome+"/jay.ui.yaml"] = &fstest.MapFile{
+				Data: []byte(`
+ui:
+  highway:
+    flags-row-position: top
+`),
+			}
+			loader := bedrock.NewViewConfigLoaderWithFS(configHome, fS)
+			cfg, err := loadHighwayConfig(loader, contract.SystemPalette())
+			Expect(err).NotTo(HaveOccurred())
+			hCfg, ok := cfg.(HighwayConfig)
+			Expect(ok).To(BeTrue())
+			Expect(hCfg.FlagsRowPosition).To(Equal(FlagsRowPositionTop))
+		})
+
+		It("accepts the bottom value", func() {
+			fS := luna.NewMemFS()
+			fS.MapFS[configHome+"/jay.ui.yaml"] = &fstest.MapFile{
+				Data: []byte(`
+ui:
+  highway:
+    flags-row-position: bottom
+`),
+			}
+			loader := bedrock.NewViewConfigLoaderWithFS(configHome, fS)
+			cfg, err := loadHighwayConfig(loader, contract.SystemPalette())
+			Expect(err).NotTo(HaveOccurred())
+			hCfg, ok := cfg.(HighwayConfig)
+			Expect(ok).To(BeTrue())
+			Expect(hCfg.FlagsRowPosition).To(Equal(FlagsRowPositionBottom))
+		})
+
+		It("falls back to bottom for an unrecognised value", func() {
+			fS := luna.NewMemFS()
+			fS.MapFS[configHome+"/jay.ui.yaml"] = &fstest.MapFile{
+				Data: []byte(`
+ui:
+  highway:
+    flags-row-position: sideways
+`),
+			}
+			loader := bedrock.NewViewConfigLoaderWithFS(configHome, fS)
+			cfg, err := loadHighwayConfig(loader, contract.SystemPalette())
+			Expect(err).NotTo(HaveOccurred())
+			hCfg, ok := cfg.(HighwayConfig)
+			Expect(ok).To(BeTrue())
+			Expect(hCfg.FlagsRowPosition).To(Equal(FlagsRowPositionBottom))
+		})
+	})
+
+	Context("when flags-row-position is absent", func() {
+		It("defaults to bottom", func() {
+			fS := luna.NewMemFS()
+			fS.MapFS[configHome+"/jay.ui.yaml"] = &fstest.MapFile{
+				Data: []byte(`
+ui:
+  highway:
+    worker-emoji-pool: '😎'
+`),
+			}
+			loader := bedrock.NewViewConfigLoaderWithFS(configHome, fS)
+			cfg, err := loadHighwayConfig(loader, contract.SystemPalette())
+			Expect(err).NotTo(HaveOccurred())
+			hCfg, ok := cfg.(HighwayConfig)
+			Expect(ok).To(BeTrue())
+			Expect(hCfg.FlagsRowPosition).To(Equal(FlagsRowPositionBottom))
+		})
+	})
+})

--- a/src/app/ui/highway.go
+++ b/src/app/ui/highway.go
@@ -31,14 +31,11 @@ type highwayPresenter struct {
 	theme      contract.Theme
 	noRecurse  bool
 
-	// Header info fields for OvertureMsg
-	cascadeDisplay string // "🔒", "depth:N", or ""
-	filesGlob      string // raw pattern when --files-glob used
-	filesRegex     string // raw pattern when --files-regex used
-	dirsGlob       string // raw pattern when --dirs-glob used
-	dirsRegex      string // raw pattern when --dirs-regex used
-	fileTypeMode   string // "glob" or "regex" for files, default "glob"
-	dirTypeMode    string // "glob" or "regex" for dirs, default "glob"
+	// header is the supplementary flag info carried on the BeginEvent.
+	// Stored on the presenter so tests and lifecycle hooks can introspect
+	// it, and read here when building the OvertureMsg. See
+	// contract.HeaderInfo for field semantics.
+	header contract.HeaderInfo
 
 	// Job emoji pool state — populated from config, random emoji picked per job arrival.
 	jobEmojiPool []string
@@ -94,7 +91,14 @@ func (h *highwayPresenter) SetMaxDepth(maxDepth uint) {
 func (h *highwayPresenter) OnBegin(e *report.BeginEvent) {
 	h.initJobEmojiPool()
 
-	// todo: derive noRecurse from e.CascadeDisplay in OnBegin or pass via options
+	// Cache the header info for introspection and for use below when
+	// building the OvertureMsg.
+	h.header = e.Header
+
+	// Derive noRecurse from cascade display. The two are mutually exclusive
+	// at the flag-binding layer, so only one of 🔒/depth can be present.
+	h.noRecurse = strings.Contains(h.header.CascadeDisplay, "🔒")
+
 	lanes := BuildHighwayLanes(h.cfg, h.noW)
 	model := highway.NewModel(lanes, highwayTickRate, e.Root, h.maxDepth, h.theme, h.noRecurse)
 	h.program = tea.NewProgram(model)
@@ -129,14 +133,11 @@ func (h *highwayPresenter) OnBegin(e *report.BeginEvent) {
 		ActionName:        e.ActionName,
 		PipelineName:      e.PipelineName,
 
-		// Header info for filter widgets and cascade display
-		CascadeDisplay: h.cascadeDisplay,
-		FilesGlob:      h.filesGlob,
-		FilesRegex:     h.filesRegex,
-		DirsGlob:       h.dirsGlob,
-		DirsRegex:      h.dirsRegex,
-		FileTypeMode:   h.fileTypeMode,
-		DirTypeMode:    h.dirTypeMode,
+		// Header info for filter widgets, cascade display and sampler
+		Header: h.header,
+
+		// Position of the flags row
+		FlagsRowPosition: h.cfg.FlagsRowPosition,
 	})
 
 	if h.totalFiles > 0 || h.totalDirs > 0 {

--- a/src/app/ui/registry.go
+++ b/src/app/ui/registry.go
@@ -30,6 +30,24 @@ const (
 )
 
 // ---------------------------------------------------------------------------
+// Flags row placement
+// ---------------------------------------------------------------------------
+
+const (
+	// FlagsRowPositionTop places the flags row immediately after the top
+	// border and before the first highway lane.
+	FlagsRowPositionTop = "top"
+
+	// FlagsRowPositionBottom places the flags row immediately above the
+	// status line and below the last highway lane (the default).
+	FlagsRowPositionBottom = "bottom"
+
+	// flagsRowPositionDefault is the value used when the configured value
+	// is empty or unrecognised.
+	flagsRowPositionDefault = FlagsRowPositionBottom
+)
+
+// ---------------------------------------------------------------------------
 // Polymorphic view configuration
 // ---------------------------------------------------------------------------
 //
@@ -95,6 +113,12 @@ type HighwayConfig struct {
 	// by LoadConfig; carried on the value so the presenter does not
 	// have to look it up again.
 	AnimationGradient string
+
+	// FlagsRowPosition is the placement of the supplementary flags row
+	// within the highway view. Allowed values are "top" and "bottom";
+	// an unrecognised value is normalised to "bottom" at load time
+	// (see loadHighwayConfig).
+	FlagsRowPosition string
 }
 
 // isViewConfig seals the implementation set.
@@ -156,6 +180,8 @@ func loadHighwayConfig(source ViewConfigSource, palette contract.Palette) (ViewC
 		}
 	}
 
+	flagsRowPosition := normaliseFlagsRowPosition(raw.FlagsRowPosition)
+
 	return HighwayConfig{
 		WorkerPool:        raw.WorkerPool,
 		JobPool:           raw.JobPool,
@@ -163,7 +189,29 @@ func loadHighwayConfig(source ViewConfigSource, palette contract.Palette) (ViewC
 		SpinnerNames:      raw.AnimationData.Spinners.Enabled,
 		AnimationGradient: nameFromPalette(palette, contract.GradientComponentActivity),
 		Overrides:         overrides,
+		FlagsRowPosition:  flagsRowPosition,
 	}, nil
+}
+
+// normaliseFlagsRowPosition validates the configured flags row position.
+// Empty values are treated as unset (use default). Unrecognised values
+// also resolve to the default; a warning is written to stderr so the
+// user is informed but the application is not aborted.
+func normaliseFlagsRowPosition(raw string) string {
+	if raw == "" {
+		return flagsRowPositionDefault
+	}
+
+	switch raw {
+	case FlagsRowPositionTop, FlagsRowPositionBottom:
+		return raw
+	default:
+		fmt.Fprintf(os.Stderr,
+			"warning: ui.highway.flags-row-position: unrecognised value %q, defaulting to %q\n",
+			raw, flagsRowPositionDefault,
+		)
+		return flagsRowPositionDefault
+	}
 }
 
 // nameFromPalette looks up the gradient name for a named component

--- a/src/prism/contract/header-info.go
+++ b/src/prism/contract/header-info.go
@@ -1,0 +1,41 @@
+package contract
+
+// HeaderInfo groups the supplementary flag values that need to be
+// extracted from the resolved traversal options for display in the
+// highway view's header and flags row. The fields are organised into
+// three loose clusters (cascade, filter, sampler) but are kept flat
+// on the struct to keep call-site field access simple.
+//
+// HeaderInfo is defined in the prism/contract package because it
+// crosses the prism/app boundary: the controller (app) populates it
+// from traversal options, then the highway model (prism) reads it
+// to render the flags row. Placing it in a contract keeps both
+// sides decoupled from each other.
+type HeaderInfo struct {
+	// CascadeDisplay holds the cascade widget value: "🔒" when
+	// --no-recurse is set, "depth:<n>" when --depth is set, or empty
+	// when neither is active.
+	CascadeDisplay string
+
+	// FilesGlob holds the --files-glob pattern (empty when unset).
+	FilesGlob string
+	// FilesRegex holds the --files-regex pattern (empty when unset).
+	FilesRegex string
+	// DirsGlob holds the --dirs-glob pattern (empty when unset).
+	DirsGlob string
+	// DirsRegex holds the --dirs-regex pattern (empty when unset).
+	DirsRegex string
+	// FileTypeMode is "regex" or "glob" indicating which of FilesRegex/
+	// FilesGlob the renderer should prefer. Defaults to "glob".
+	FileTypeMode string
+	// DirTypeMode is "regex" or "glob" indicating which of DirsRegex/
+	// DirsGlob the renderer should prefer. Defaults to "glob".
+	DirTypeMode string
+
+	// NumFiles is the --num-files value (0 when unset).
+	NumFiles uint
+	// NumFolders is the --num-folders value (0 means unset).
+	NumFolders uint
+	// SampleLast is true when --last was specified.
+	SampleLast bool
+}

--- a/src/prism/highway/highway-defs.go
+++ b/src/prism/highway/highway-defs.go
@@ -10,3 +10,14 @@ const (
 	// so all following columns stay aligned.
 	SpinnerNameWidth = 18
 )
+
+// Flags row placement - mirrors ui.FlagsRowPosition*.
+const (
+	// FlagsRowPositionTop places the flags row immediately after the top
+	// border and before the first highway lane.
+	FlagsRowPositionTop = "top"
+
+	// FlagsRowPositionBottom places the flags row immediately above the
+	// status line and below the last highway lane (the default).
+	FlagsRowPositionBottom = "bottom"
+)

--- a/src/prism/highway/messages.go
+++ b/src/prism/highway/messages.go
@@ -15,14 +15,14 @@ type OvertureMsg struct {
 	ActionName        string
 	PipelineName      string
 
-	// header information for filter widgets and depth indicator
-	CascadeDisplay string // "🔒", "depth:<n>", or ""
-	FilesGlob      string // pattern value when --files-glob or -f used
-	FilesRegex     string // pattern value when --files-regex used
-	DirsGlob       string // pattern value when --dirs-glob used
-	DirsRegex      string // pattern value when --dirs-regex used
-	FileTypeMode   string // "glob" or "regex" for files
-	DirTypeMode    string // "glob" or "regex" for dirs
+	// Header groups the supplementary flag values for the flags row
+	// renderer. See contract.HeaderInfo for the field semantics.
+	Header contract.HeaderInfo
+
+	// FlagsRowPosition selects where the flags row is rendered. Allowed
+	// values are "top" and "bottom"; any other value is treated as
+	// "bottom" (the default).
+	FlagsRowPosition string
 }
 
 type MotifData struct {

--- a/src/prism/highway/model.go
+++ b/src/prism/highway/model.go
@@ -43,14 +43,17 @@ type Model struct {
 	counted           map[string]bool
 	errMsg            string
 
-	// header filter and cascade display info (populated by OvertureMsg)
-	CascadeDisplay string // "🔒", "depth:<n>", or ""
-	FilesGlob      string // raw pattern value
-	FilesRegex     string // raw pattern value
-	DirsGlob       string // raw pattern value
-	DirsRegex      string // raw pattern value
-	FileTypeMode   string // "glob" or "regex" for files
-	DirTypeMode    string // "glob" or "regex" for dirs
+	// header is the supplementary flag info carried on the OvertureMsg.
+	// Stored on the model so renderFlagsRow and other renderers can
+	// access it without further plumbing. See contract.HeaderInfo for
+	// the field semantics.
+	header contract.HeaderInfo
+
+	// FlagsRowPosition controls where the flags row is rendered. See
+	// contract/... or the theme config; "top" places it after the top
+	// border, "bottom" places it above the status line. The default
+	// applied by the loader is "bottom".
+	FlagsRowPosition string
 }
 
 // initLaneSkip computes the per-lane skip factor from each lane's
@@ -182,14 +185,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.caption = msg.Caption
 		m.dateFormat = msg.DateFormat
 
-		// store header widgets info
-		m.CascadeDisplay = msg.CascadeDisplay
-		m.FilesGlob = msg.FilesGlob
-		m.FilesRegex = msg.FilesRegex
-		m.DirsGlob = msg.DirsGlob
-		m.DirsRegex = msg.DirsRegex
-		m.FileTypeMode = msg.FileTypeMode
-		m.DirTypeMode = msg.DirTypeMode
+		// Cache the header info for renderers.
+		m.header = msg.Header
+
+		// store flags row position; default to "bottom" for empty/invalid
+		m.FlagsRowPosition = msg.FlagsRowPosition
+		if m.FlagsRowPosition != FlagsRowPositionTop && m.FlagsRowPosition != FlagsRowPositionBottom {
+			m.FlagsRowPosition = FlagsRowPositionBottom
+		}
 
 		return m, nil
 

--- a/src/prism/highway/render-flags-row.go
+++ b/src/prism/highway/render-flags-row.go
@@ -1,0 +1,142 @@
+package highway
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/snivilised/jaywalk/src/prism/layout"
+	"github.com/snivilised/jaywalk/src/prism/widgets/cascade"
+	"github.com/snivilised/jaywalk/src/prism/widgets/filter"
+	"github.com/snivilised/jaywalk/src/prism/widgets/sampler"
+)
+
+// flagsRowSeparator is the separator that joins consecutive flag
+// entries on the same wrapped line. The surrounding single spaces
+// distinguish each entry from its neighbours, as required by the spec.
+const flagsRowSeparator = " | "
+
+// renderFlagsRow emits zero or more wrapped lines representing the
+// supplementary flags (cascade / filters / sampler) and finishes with
+// a border separator that closes the section. When no flag is active,
+// the function is a no-op so callers do not need to guard.
+func (m Model) renderFlagsRow(b *strings.Builder) {
+	borderStyle := m.theme.BorderStyle
+	// Strip the column width from SummaryLabelStyle: the closing summary
+	// uses Width(16) to align labels in a column, but the flags row is
+	// inline, so padding the label to 16 would push the colon away from
+	// the label text (e.g. "files glob      : *.go" instead of the
+	// desired "files glob: *.go"). Setting Width(0) on a lipgloss style
+	// removes the width constraint.
+	summaryLabelStyle := m.theme.SummaryLabelStyle.Width(0)
+	summaryValueStyle := m.theme.SummaryValueStyle
+
+	// Collect the active flag entries in the order specified by the spec:
+	// cascade (lock or depth) → filter labels → sampler labels.
+	entries := m.composeFlagsRowEntries(summaryLabelStyle, summaryValueStyle)
+	if len(entries) == 0 {
+		return
+	}
+
+	// Wrap the entries into lines that fit within the available width.
+	// width-4 accounts for the "│ " left cap and " │" right cap.
+	available := m.width - 4
+	if available < 1 {
+		available = 1
+	}
+	lines := wrapFlagsRow(entries, flagsRowSeparator, available)
+
+	for _, line := range lines {
+		row := layout.NewRow(m.width - 4).
+			Caps(borderStyle.Render("│ "), borderStyle.Render(" │")).
+			Content(line)
+		row.RenderTo(b)
+		b.WriteString("\n")
+	}
+
+	// Close the flags row section with a separator border, matching the
+	// look of the existing top/lane separators.
+	dashes := strings.Repeat("─", max(0, m.width-2))
+	b.WriteString(borderStyle.Render("├" + dashes + "┤"))
+	b.WriteString("\n")
+}
+
+// composeFlagsRowEntries returns the individual flag entries in
+// spec-mandated order. Each entry is already rendered with the
+// appropriate style. Returns an empty slice when no flag is set.
+//
+// summaryLabelStyle is applied to label text (e.g. "files glob",
+// "#files", "🐌") and summaryValueStyle is applied to the value text
+// (e.g. the pattern strings, the numeric counts). The cascade widget
+// has no associated label, so its single value is rendered with
+// summaryValueStyle.
+func (m Model) composeFlagsRowEntries(
+	summaryLabelStyle lipgloss.Style,
+	summaryValueStyle lipgloss.Style,
+) []string {
+	var entries []string
+
+	if entry := cascade.Render(m.header.CascadeDisplay, cascade.Styles{
+		ValueStyle: summaryValueStyle,
+	}); entry != "" {
+		entries = append(entries, entry)
+	}
+
+	if entry := filter.Render(m.header.FilesGlob, m.header.FilesRegex, m.header.DirsGlob, m.header.DirsRegex,
+		m.header.FileTypeMode, m.header.DirTypeMode, filter.Styles{
+			LabelStyle: summaryLabelStyle,
+			ValueStyle: summaryValueStyle,
+		}); entry != "" {
+		entries = append(entries, entry)
+	}
+
+	if entry := sampler.Render(m.header.NumFiles, m.header.NumFolders, m.header.SampleLast, sampler.Styles{
+		LabelStyle: summaryLabelStyle,
+		ValueStyle: summaryValueStyle,
+	}); entry != "" {
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+// wrapFlagsRow partitions a sequence of pre-rendered entries into
+// lines whose visual width is no greater than maxWidth. Entries are
+// joined by the supplied separator. When a single entry is itself
+// wider than maxWidth, it is placed alone on its own line (we do not
+// split within an entry).
+func wrapFlagsRow(entries []string, separator string, maxWidth int) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	var lines []string
+	var current []string
+	currentWidth := 0
+
+	for _, entry := range entries {
+		w := lipgloss.Width(entry)
+		sepWidth := lipgloss.Width(separator)
+
+		switch {
+		case len(current) == 0:
+			current = append(current, entry)
+			currentWidth = w
+
+		case currentWidth+sepWidth+w <= maxWidth:
+			current = append(current, entry)
+			currentWidth += sepWidth + w
+
+		default:
+			lines = append(lines, strings.Join(current, separator))
+			current = []string{entry}
+			currentWidth = w
+		}
+	}
+
+	if len(current) > 0 {
+		lines = append(lines, strings.Join(current, separator))
+	}
+
+	return lines
+}

--- a/src/prism/highway/render-flags-row_test.go
+++ b/src/prism/highway/render-flags-row_test.go
@@ -1,0 +1,284 @@
+package highway
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+)
+
+const (
+	// padlockRune is the cascade widget value used across the
+	// flags-row specs. Lifted into a constant to satisfy the
+	// goconst linter check for repeated string literals.
+	padlockRune = "🔒"
+
+	// filesGlobPattern is the --files-glob value used in the
+	// flags-row specs. Lifted into a constant for the same reason
+	// as padlockRune.
+	filesGlobPattern = "*.go"
+)
+
+var _ = Describe("wrapFlagsRow", func() {
+	It("returns nil for an empty entry slice", func() {
+		Expect(wrapFlagsRow(nil, " | ", 80)).To(BeNil())
+		Expect(wrapFlagsRow([]string{}, " | ", 80)).To(BeNil())
+	})
+
+	It("places a single entry on one line", func() {
+		got := wrapFlagsRow([]string{"alpha"}, " | ", 80)
+		Expect(got).To(Equal([]string{"alpha"}))
+	})
+
+	It("joins entries on a single line when they fit", func() {
+		got := wrapFlagsRow([]string{"a", "b", "c"}, " | ", 80)
+		Expect(got).To(Equal([]string{"a | b | c"}))
+	})
+
+	It("wraps to a new line when the next entry would overflow", func() {
+		got := wrapFlagsRow([]string{"aaaaa", "bbbbb", "ccccc"}, " | ", 14)
+		// aaaaa (5) + " | " (3) + bbbbb (5) = 13, fits within 14
+		// adding ccccc would be 13 + 3 + 5 = 21, so it wraps to a new line
+		Expect(got).To(Equal([]string{"aaaaa | bbbbb", "ccccc"}))
+	})
+
+	It("each entry becomes its own line when no two fit together", func() {
+		got := wrapFlagsRow([]string{"aaaaa", "bbbbb", "ccccc"}, " | ", 11)
+		// 5 + 3 + 5 = 13, exceeds 11, so no two fit together
+		Expect(got).To(Equal([]string{"aaaaa", "bbbbb", "ccccc"}))
+	})
+
+	It("keeps a single overlong entry on its own line", func() {
+		got := wrapFlagsRow([]string{"way-too-long"}, " | ", 5)
+		Expect(got).To(Equal([]string{"way-too-long"}))
+	})
+
+	It("preserves the configured separator verbatim", func() {
+		got := wrapFlagsRow([]string{"a", "b"}, "##", 80)
+		Expect(got[0]).To(ContainSubstring("##"))
+		Expect(got[0]).NotTo(ContainSubstring("|"))
+	})
+})
+
+var _ = Describe("composeFlagsRowEntries", func() {
+	// helper that returns a model with the given string fields set
+	modelWith := func(cascade, filesGlob, dirsGlob string,
+		numFiles, numFolders uint, sampleLast bool) Model {
+		return Model{
+			header: contract.HeaderInfo{
+				CascadeDisplay: cascade,
+				FilesGlob:      filesGlob,
+				DirsGlob:       dirsGlob,
+				NumFiles:       numFiles,
+				NumFolders:     numFolders,
+				SampleLast:     sampleLast,
+			},
+		}
+	}
+
+	It("returns an empty slice when no flags are set", func() {
+		m := modelWith("", "", "", 0, 0, false)
+		entries := m.composeFlagsRowEntries(testTheme().HeaderStyle, testTheme().SummaryValueStyle)
+		Expect(entries).To(BeEmpty())
+	})
+
+	It("emits a single entry for the cascade widget", func() {
+		m := modelWith(padlockRune, "", "", 0, 0, false)
+		entries := m.composeFlagsRowEntries(testTheme().HeaderStyle, testTheme().SummaryValueStyle)
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0]).To(ContainSubstring(padlockRune))
+	})
+
+	It("emits one entry per active filter", func() {
+		m := modelWith("", filesGlobPattern, "src/*", 0, 0, false)
+		entries := m.composeFlagsRowEntries(testTheme().HeaderStyle, testTheme().SummaryValueStyle)
+		Expect(entries).To(HaveLen(1)) // filter widget bundles all filters into one entry
+		Expect(entries[0]).To(ContainSubstring("files glob"))
+		Expect(entries[0]).To(ContainSubstring("dirs glob"))
+	})
+
+	It("emits a sampler entry when sampleLast is set", func() {
+		m := modelWith("", "", "", 0, 0, true)
+		entries := m.composeFlagsRowEntries(testTheme().HeaderStyle, testTheme().SummaryValueStyle)
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0]).To(ContainSubstring("🐌"))
+	})
+
+	It("emits all three widget entries in spec order", func() {
+		m := modelWith(padlockRune, filesGlobPattern, "", 10, 5, true)
+		entries := m.composeFlagsRowEntries(testTheme().HeaderStyle, testTheme().SummaryValueStyle)
+		Expect(entries).To(HaveLen(3))
+		// First entry is the cascade
+		Expect(entries[0]).To(ContainSubstring(padlockRune))
+		// Second is the filter
+		Expect(entries[1]).To(ContainSubstring("files glob"))
+		// Third is the sampler
+		Expect(entries[2]).To(ContainSubstring("🐌"))
+		Expect(entries[2]).To(ContainSubstring("#files"))
+		Expect(entries[2]).To(ContainSubstring("#dirs"))
+	})
+})
+
+var _ = Describe("renderFlagsRow", func() {
+	It("is a no-op when no flag is active", func() {
+		m := baseModel(1)
+		m.FlagsRowPosition = FlagsRowPositionTop
+		var b strings.Builder
+		m.renderFlagsRow(&b)
+		Expect(b.String()).To(BeEmpty())
+	})
+
+	It("emits a separator border when at least one flag is active", func() {
+		m := baseModel(1)
+		m.FlagsRowPosition = FlagsRowPositionBottom
+		m.header.CascadeDisplay = padlockRune
+		var b strings.Builder
+		m.renderFlagsRow(&b)
+		out := b.String()
+		Expect(out).To(ContainSubstring(padlockRune))
+		Expect(out).To(ContainSubstring("├"))
+		Expect(out).To(ContainSubstring("┤"))
+	})
+
+	It("composes multiple widgets into a single line with the pipe separator", func() {
+		m := baseModel(1)
+		m.FlagsRowPosition = FlagsRowPositionBottom
+		m.header.CascadeDisplay = padlockRune
+		m.header.FilesGlob = filesGlobPattern
+		var b strings.Builder
+		m.renderFlagsRow(&b)
+		out := b.String()
+		Expect(out).To(ContainSubstring(padlockRune))
+		Expect(out).To(ContainSubstring("|"))
+		Expect(out).To(ContainSubstring("files glob"))
+	})
+
+	It("places the colon immediately after the label (no column padding)", func() {
+		m := baseModel(1)
+		m.FlagsRowPosition = FlagsRowPositionBottom
+		m.header.FilesGlob = filesGlobPattern
+		var b strings.Builder
+		m.renderFlagsRow(&b)
+		out := b.String()
+		// The label "files glob" must be followed immediately by ":" with
+		// no intermediate padding. SummaryLabelStyle has Width(16) for
+		// the closing summary's column alignment, but the flags row
+		// renders inline so renderFlagsRow must strip that width.
+		// We strip ANSI escape codes before substring matching, because
+		// the styled label injects reset codes that interrupt a literal
+		// "files glob:" match.
+		Expect(stripANSI(out)).To(ContainSubstring("files glob:"))
+		Expect(stripANSI(out)).NotTo(ContainSubstring("files glob      :"))
+	})
+
+	It("places the pipe separator between entries with surrounding spaces", func() {
+		m := baseModel(1)
+		m.FlagsRowPosition = FlagsRowPositionBottom
+		m.header.CascadeDisplay = padlockRune
+		m.header.FilesGlob = filesGlobPattern
+		m.header.NumFiles = 10
+		var b strings.Builder
+		m.renderFlagsRow(&b)
+		out := b.String()
+		// Three entries (cascade, filter, sampler) should produce two
+		// " | " separators on the same line.
+		Expect(strings.Count(out, " | ")).To(BeNumerically(">=", 2))
+	})
+
+	It("produces the spec example format with all secondary flags set", func() {
+		m := baseModel(1)
+		m.width = 200 // wide enough to fit everything on one line
+		m.FlagsRowPosition = FlagsRowPositionBottom
+		// Note: glob/regex are mutually exclusive per family (enforced
+		// at flag binding), but the spec example shows both for format
+		// illustration. We pick the realistic case: one per family.
+		m.header.CascadeDisplay = "depth:3"
+		m.header.FilesGlob = "*.go"
+		m.header.DirsRegex = `^\.`
+		m.header.NumFiles = 100
+		m.header.NumFolders = 10
+		m.header.SampleLast = true
+		var b strings.Builder
+		m.renderFlagsRow(&b)
+		out := stripANSI(b.String())
+		// spec example shape: `depth: 3 | files glob: *.go | ... | dirs regex: ^\. | 🐌 | #files: 100 | #dirs: 10`
+		Expect(out).To(ContainSubstring("depth:3"))
+		Expect(out).To(ContainSubstring("files glob: *.go"))
+		Expect(out).To(ContainSubstring("dirs regex: ^\\."))
+		Expect(out).To(ContainSubstring("🐌"))
+		Expect(out).To(ContainSubstring("#files: 100"))
+		Expect(out).To(ContainSubstring("#dirs: 10"))
+		// Every flag should be joined with " | " - cascade + filter +
+		// sampler emits 3 entries joined by 2 separators, plus the
+		// filter widget internally uses " | " too (1) and the sampler
+		// widget does too (2). Total: 2 + 1 + 2 = 5.
+		Expect(strings.Count(out, " | ")).To(Equal(5))
+	})
+
+	// regression: when only --files is set, the user reported
+	// "files glob: *|.go, dirs regex: ." (with stale benign default
+	// bleeding through). After the fix, only the user's actual
+	// filter should appear.
+	It("does not surface a benign default for un-set dir filter when only --files is set", func() {
+		m := baseModel(1)
+		m.width = 200
+		m.FlagsRowPosition = FlagsRowPositionBottom
+		m.header.FilesGlob = "*|.go"
+		var b strings.Builder
+		m.renderFlagsRow(&b)
+		out := stripANSI(b.String())
+		Expect(out).To(ContainSubstring("files glob: *|.go"))
+		Expect(out).NotTo(ContainSubstring("dirs regex"))
+		Expect(out).NotTo(ContainSubstring("dirs glob"))
+		Expect(out).NotTo(ContainSubstring("files regex"))
+	})
+
+	It("wraps onto a second line when the content exceeds the width", func() {
+		m := baseModel(1)
+		m.width = 30 // narrow
+		m.FlagsRowPosition = FlagsRowPositionBottom
+		m.header.CascadeDisplay = padlockRune
+		m.header.FilesGlob = filesGlobPattern
+		m.header.DirsGlob = "src/*"
+		m.header.NumFiles = 100
+		m.header.NumFolders = 50
+		m.header.SampleLast = true
+		var b strings.Builder
+		m.renderFlagsRow(&b)
+		out := b.String()
+		// With 4 chars of borders, available width is 26; total unwrapped content
+		// is ~60 chars, so we expect at least 2 wrapped content lines (plus the
+		// closing separator border makes 3 newline-terminated lines).
+		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+		Expect(len(lines)).To(BeNumerically(">=", 2))
+	})
+})
+
+var _ = Describe("Model.FlagsRowPosition defaulting", func() {
+	It("defaults to bottom when the OvertureMsg position is empty", func() {
+		m := baseModel(1)
+		m.FlagsRowPosition = ""
+		updated, _ := update(m, OvertureMsg{FlagsRowPosition: ""})
+		Expect(updated.FlagsRowPosition).To(Equal(FlagsRowPositionBottom))
+	})
+
+	It("defaults to bottom when the OvertureMsg position is unrecognised", func() {
+		m := baseModel(1)
+		updated, _ := update(m, OvertureMsg{FlagsRowPosition: "sideways"})
+		Expect(updated.FlagsRowPosition).To(Equal(FlagsRowPositionBottom))
+	})
+
+	It("preserves a top position from the OvertureMsg", func() {
+		m := baseModel(1)
+		updated, _ := update(m, OvertureMsg{FlagsRowPosition: FlagsRowPositionTop})
+		Expect(updated.FlagsRowPosition).To(Equal(FlagsRowPositionTop))
+	})
+
+	It("preserves an explicit bottom position from the OvertureMsg", func() {
+		m := baseModel(1)
+		updated, _ := update(m, OvertureMsg{FlagsRowPosition: FlagsRowPositionBottom})
+		Expect(updated.FlagsRowPosition).To(Equal(FlagsRowPositionBottom))
+	})
+})

--- a/src/prism/highway/render-header.go
+++ b/src/prism/highway/render-header.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/snivilised/jaywalk/src/prism/layout"
 	"github.com/snivilised/jaywalk/src/prism/widgets/border"
-	"github.com/snivilised/jaywalk/src/prism/widgets/cascade"
-	"github.com/snivilised/jaywalk/src/prism/widgets/filter"
 	"github.com/snivilised/jaywalk/src/prism/widgets/intro"
 	"github.com/snivilised/jaywalk/src/prism/widgets/pipeline"
 )
@@ -27,27 +25,17 @@ func (m Model) renderHeader(b *strings.Builder) {
 	})
 	b.WriteString(topBorderContent)
 
-	// Render Date/Time and Cascade
+	// Render the intro line. The intro contains primary flags only
+	// (subscription, date/time) - the cascade (lock/depth) and filter
+	// information have been moved to the flags row renderer to keep all
+	// supplementary flag presentation in one place.
 	introContent := intro.Render(m.subscriptionLabel, m.startedAt, m.dateFormat, intro.Styles{
 		InfoStyle: summaryValueStyle,
 	})
-	cascadeWidget := cascade.Render(m.CascadeDisplay, cascade.Styles{
-		HeaderStyle: headerStyle,
-	})
-
-	var infoPart string
-	if introContent != "" {
-		infoPart = introContent
-		if cascadeWidget != "" {
-			infoPart = infoPart + " │" + cascadeWidget
-		}
-	} else if cascadeWidget != "" {
-		infoPart = cascadeWidget
-	}
 
 	// Render header text
 	header := headerStyle.Render("Processing")
-	middle := header + infoPart
+	middle := header + introContent
 
 	row := layout.NewRow(m.width-4).
 		Caps(borderStyle.Render("│ "), borderStyle.Render(" │")).
@@ -59,15 +47,6 @@ func (m Model) renderHeader(b *strings.Builder) {
 	})
 	if pipelineContent != "" {
 		row.RightContent(pipelineContent)
-	}
-
-	// Render Filter Info
-	filterContent := filter.Render(m.FilesGlob, m.FilesRegex, m.DirsGlob, m.DirsRegex,
-		m.FileTypeMode, m.DirTypeMode, filter.Styles{
-			InfoStyle: summaryValueStyle,
-		})
-	if filterContent != "" {
-		row.RightContent(filterContent)
 	}
 
 	row.RenderTo(b)

--- a/src/prism/highway/view.go
+++ b/src/prism/highway/view.go
@@ -10,7 +10,13 @@ func (m Model) View() tea.View {
 	var b strings.Builder
 
 	m.renderHeader(&b)
+	if m.FlagsRowPosition == FlagsRowPositionTop {
+		m.renderFlagsRow(&b)
+	}
 	m.renderLanes(&b)
+	if m.FlagsRowPosition == FlagsRowPositionBottom || m.FlagsRowPosition == "" {
+		m.renderFlagsRow(&b)
+	}
 	m.renderSummary(&b)
 
 	v := tea.NewView(b.String())

--- a/src/prism/widgets/cascade/cascade.go
+++ b/src/prism/widgets/cascade/cascade.go
@@ -6,8 +6,11 @@ import (
 
 // Styles defines the styles used to render the cascade display widget.
 type Styles struct {
-	// HeaderStyle is applied to the cascade display text.
-	HeaderStyle lipgloss.Style
+	// ValueStyle is applied to the cascade display text. The cascade
+	// widget renders a single value (lock emoji or depth value) with
+	// no associated label, so the value style is the only style it
+	// needs.
+	ValueStyle lipgloss.Style
 }
 
 // Render renders the cascade display widget (lock emoji or depth value).
@@ -16,5 +19,5 @@ func Render(cascade string, styles Styles) string {
 	if cascade == "" {
 		return ""
 	}
-	return styles.HeaderStyle.Render(cascade)
+	return styles.ValueStyle.Render(cascade)
 }

--- a/src/prism/widgets/cascade/cascade_test.go
+++ b/src/prism/widgets/cascade/cascade_test.go
@@ -9,24 +9,24 @@ import (
 
 var _ = Describe("Cascade.Render", func() {
 	It("returns empty string for empty cascade", func() {
-		styles := Styles{HeaderStyle: lipgloss.NewStyle()}
+		styles := Styles{ValueStyle: lipgloss.NewStyle()}
 		result := Render("", styles)
 		Expect(result).To(Equal(""))
 	})
 
 	It("returns styled cascade value", func() {
-		headerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
-		styles := Styles{HeaderStyle: headerStyle}
+		valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+		styles := Styles{ValueStyle: valueStyle}
 		cascade := "🔒"
 		result := Render(cascade, styles)
-		Expect(result).To(Equal(headerStyle.Render(cascade)))
+		Expect(result).To(Equal(valueStyle.Render(cascade)))
 	})
 
 	It("returns styled depth value", func() {
-		headerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
-		styles := Styles{HeaderStyle: headerStyle}
+		valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+		styles := Styles{ValueStyle: valueStyle}
 		cascade := "depth:5"
 		result := Render(cascade, styles)
-		Expect(result).To(Equal(headerStyle.Render(cascade)))
+		Expect(result).To(Equal(valueStyle.Render(cascade)))
 	})
 })

--- a/src/prism/widgets/filter/filter.go
+++ b/src/prism/widgets/filter/filter.go
@@ -1,22 +1,38 @@
 package filter
 
 import (
-	"fmt"
-	"strings"
-
 	"charm.land/lipgloss/v2"
 )
 
 // Styles defines the styles used to render the filter info widget.
 type Styles struct {
-	// InfoStyle is applied to the filter information text.
-	InfoStyle lipgloss.Style
+	// LabelStyle is applied to the label part of each rendered entry
+	// (e.g. "files glob" in "files glob: *.go").
+	LabelStyle lipgloss.Style
+
+	// ValueStyle is applied to the value part of each rendered entry
+	// (e.g. "*.go" in "files glob: *.go").
+	ValueStyle lipgloss.Style
 }
 
-// Render renders the filter information widget.
-// It displays active filters (filesGlob, filesRegex, dirsGlob, dirsRegex) with precedence rules.
-// Returns an empty string if no filters are active.
-// The output format is " └─ [ filter1:value1, filter2:value2 ]".
+// Render renders the filter information widget as a list of labelled
+// values for any active filters. Active filters are those whose
+// corresponding pattern is non-empty. Returns an empty string when no
+// filters are active.
+//
+// Labels are human-readable and use spaces (not the CLI dash form):
+//
+//	files glob: <pattern>
+//	files regex: <pattern>
+//	dirs glob: <pattern>
+//	dirs regex: <pattern>
+//
+// Per the spec (issue 568), consecutive entries are separated by
+// " | " (single space, pipe, single space) - the same separator used
+// between distinct widgets in the flags row. This produces the
+// expected output:
+//
+//	files glob: *.go | dirs regex: src/.*
 func Render(filesGlob, filesRegex, dirsGlob, dirsRegex string,
 	fileTypeMode, dirTypeMode string, styles Styles) string {
 	if filesGlob == "" && filesRegex == "" &&
@@ -27,20 +43,40 @@ func Render(filesGlob, filesRegex, dirsGlob, dirsRegex string,
 	var parts []string
 
 	if filesGlob != "" {
-		parts = append(parts, fmt.Sprintf("files-glob:%s", filesGlob))
+		parts = append(parts, labelValue(styles, "files glob", filesGlob))
 	} else if filesRegex != "" {
-		parts = append(parts, fmt.Sprintf("files-regex:%s", filesRegex))
+		parts = append(parts, labelValue(styles, "files regex", filesRegex))
 	}
 
 	if dirsGlob != "" {
-		parts = append(parts, fmt.Sprintf("dirs-glob:%s", dirsGlob))
+		parts = append(parts, labelValue(styles, "dirs glob", dirsGlob))
 	} else if dirsRegex != "" {
-		parts = append(parts, fmt.Sprintf("dirs-regex:%s", dirsRegex))
+		parts = append(parts, labelValue(styles, "dirs regex", dirsRegex))
 	}
 
 	if len(parts) == 0 {
 		return ""
 	}
 
-	return styles.InfoStyle.Render(" └─ [ " + strings.Join(parts, ", ") + " ]")
+	return joinParts(parts)
+}
+
+// labelValue renders "<label>: <value>" with the label and value each
+// receiving their respective style.
+func labelValue(styles Styles, label, value string) string {
+	return styles.LabelStyle.Render(label) + ": " + styles.ValueStyle.Render(value)
+}
+
+// joinParts joins the rendered parts with " | " (single space, pipe,
+// single space). The separator is unstyled so that it does not get
+// coloured. This matches the spec's field separator.
+func joinParts(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += " | "
+		}
+		out += p
+	}
+	return out
 }

--- a/src/prism/widgets/filter/filter_test.go
+++ b/src/prism/widgets/filter/filter_test.go
@@ -8,45 +8,71 @@ import (
 )
 
 var _ = Describe("Filter.Render", func() {
+	noStyles := Styles{
+		LabelStyle: lipgloss.NewStyle(),
+		ValueStyle: lipgloss.NewStyle(),
+	}
+
 	It("returns empty when no filters active", func() {
-		styles := Styles{InfoStyle: lipgloss.NewStyle()}
-		result := Render("", "", "", "", "", "", styles)
+		result := Render("", "", "", "", "", "", noStyles)
 		Expect(result).To(Equal(""))
 	})
 
 	It("shows files glob before files regex", func() {
-		styles := Styles{InfoStyle: lipgloss.NewStyle()}
 		filesGlob := "*.go"
 		filesRegex := `.*\.go`
-		expect := " └─ [ files-glob:*.go ]"
-		result := Render(filesGlob, filesRegex, "", "", "", "", styles)
+		expect := "files glob: *.go"
+		result := Render(filesGlob, filesRegex, "", "", "", "", noStyles)
 		Expect(result).To(Equal(expect))
 	})
 
 	It("shows dirs glob before dirs regex", func() {
-		styles := Styles{InfoStyle: lipgloss.NewStyle()}
 		dirsGlob := "src/*"
 		dirsRegex := "src/.*"
-		expect := " └─ [ dirs-glob:src/* ]"
-		result := Render("", "", dirsGlob, dirsRegex, "", "", styles)
+		expect := "dirs glob: src/*"
+		result := Render("", "", dirsGlob, dirsRegex, "", "", noStyles)
 		Expect(result).To(Equal(expect))
 	})
 
 	It("handles multiple filter types", func() {
-		styles := Styles{InfoStyle: lipgloss.NewStyle()}
 		filesGlob := "*.go"
 		dirsRegex := "src/.*"
-		expect := " └─ [ files-glob:*.go, dirs-regex:src/.* ]"
-		result := Render(filesGlob, "", "", dirsRegex, "", "", styles)
+		expect := "files glob: *.go | dirs regex: src/.*"
+		result := Render(filesGlob, "", "", dirsRegex, "", "", noStyles)
 		Expect(result).To(Equal(expect))
 	})
 
-	It("applies InfoStyle", func() {
-		infoStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
-		styles := Styles{InfoStyle: infoStyle}
+	It("uses spaces in labels (not CLI dash form)", func() {
 		filesGlob := "*.js"
-		expect := " └─ [ files-glob:*.js ]"
+		result := Render(filesGlob, "", "", "", "", "", noStyles)
+		Expect(result).To(Equal("files glob: *.js"))
+		Expect(result).NotTo(ContainSubstring("files-glob"))
+		Expect(result).NotTo(ContainSubstring("dirs-glob"))
+	})
+
+	It("applies LabelStyle to labels and ValueStyle to values", func() {
+		labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("4"))
+		valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+		styles := Styles{
+			LabelStyle: labelStyle,
+			ValueStyle: valueStyle,
+		}
+		filesGlob := "*.js"
+		expect := labelStyle.Render("files glob") + ": " + valueStyle.Render("*.js")
 		result := Render(filesGlob, "", "", "", "", "", styles)
-		Expect(result).To(Equal(infoStyle.Render(expect)))
+		Expect(result).To(Equal(expect))
+	})
+
+	It("preserves the separator between label and value (uncoloured)", func() {
+		labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("4"))
+		valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+		styles := Styles{
+			LabelStyle: labelStyle,
+			ValueStyle: valueStyle,
+		}
+		result := Render("*.js", "", "", "", "", "", styles)
+		Expect(result).To(ContainSubstring(": "))
+		// The ": " between label and value is intentionally uncoloured
+		// so that the boundary between them is visually clean.
 	})
 })

--- a/src/prism/widgets/sampler/sampler-suite_test.go
+++ b/src/prism/widgets/sampler/sampler-suite_test.go
@@ -1,4 +1,4 @@
-package filter
+package sampler
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestAction(t *testing.T) {
+func TestSampler(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Filter Suite")
+	RunSpecs(t, "Sampler Suite")
 }

--- a/src/prism/widgets/sampler/sampler.go
+++ b/src/prism/widgets/sampler/sampler.go
@@ -1,0 +1,82 @@
+package sampler
+
+import (
+	"fmt"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Styles defines the styles used to render the sampler info widget.
+type Styles struct {
+	// LabelStyle is applied to the label part of each rendered entry
+	// (e.g. "#files" in "#files: 10") and to the 🐌 indicator which
+	// has no associated value.
+	LabelStyle lipgloss.Style
+
+	// ValueStyle is applied to the value part of each rendered entry
+	// (e.g. "10" in "#files: 10").
+	ValueStyle lipgloss.Style
+}
+
+// Render renders the sampler info widget as a list of labelled values
+// for any active sampler flags. Returns an empty string when sampling
+// is not active (no fields set).
+//
+// Item order is fixed and matches the spec:
+//
+//	🐌  (when SampleLast is true)
+//	#files: <n>   (when NumFiles > 0)
+//	#dirs: <n>    (when NumFolders > 0)
+//
+// The 🐌 emoji is a boolean indicator for the --last flag and always
+// precedes the count items when present. Numeric values of zero are
+// treated as unset so the caller does not need to track whether the
+// user supplied a zero count.
+//
+// Per the spec (issue 568), consecutive entries are separated by
+// " | " (single space, pipe, single space) - the same separator used
+// between distinct widgets in the flags row.
+func Render(numFiles, numFolders uint, sampleLast bool, styles Styles) string {
+	if numFiles == 0 && numFolders == 0 && !sampleLast {
+		return ""
+	}
+
+	var parts []string
+
+	if sampleLast {
+		parts = append(parts, styles.LabelStyle.Render("🐌"))
+	}
+	if numFiles > 0 {
+		parts = append(parts, labelValue(styles, "#files", numFiles))
+	}
+	if numFolders > 0 {
+		parts = append(parts, labelValue(styles, "#dirs", numFolders))
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return joinParts(parts)
+}
+
+// labelValue renders "<label>: <n>" with the label and value each
+// receiving their respective style.
+func labelValue(styles Styles, label string, value uint) string {
+	return styles.LabelStyle.Render(label) + ": " +
+		styles.ValueStyle.Render(fmt.Sprintf("%d", value))
+}
+
+// joinParts joins the rendered parts with " | " (single space, pipe,
+// single space). The separator is unstyled so that it does not get
+// coloured. This matches the spec's field separator.
+func joinParts(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += " | "
+		}
+		out += p
+	}
+	return out
+}

--- a/src/prism/widgets/sampler/sampler_test.go
+++ b/src/prism/widgets/sampler/sampler_test.go
@@ -1,0 +1,74 @@
+package sampler
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"charm.land/lipgloss/v2"
+)
+
+var _ = Describe("Sampler.Render", func() {
+	noStyles := Styles{
+		LabelStyle: lipgloss.NewStyle(),
+		ValueStyle: lipgloss.NewStyle(),
+	}
+
+	It("returns empty when no sampler fields active", func() {
+		result := Render(0, 0, false, noStyles)
+		Expect(result).To(Equal(""))
+	})
+
+	It("renders the 🐌 emoji when --last is set", func() {
+		result := Render(0, 0, true, noStyles)
+		Expect(result).To(Equal("🐌"))
+	})
+
+	It("renders #files when numFiles is positive", func() {
+		result := Render(10, 0, false, noStyles)
+		Expect(result).To(Equal("#files: 10"))
+	})
+
+	It("renders #dirs when numFolders is positive", func() {
+		result := Render(0, 5, false, noStyles)
+		Expect(result).To(Equal("#dirs: 5"))
+	})
+
+	It("places 🐌 before the count items", func() {
+		result := Render(10, 5, true, noStyles)
+		Expect(result).To(Equal("🐌 | #files: 10 | #dirs: 5"))
+	})
+
+	It("places #files before #dirs when 🐌 is absent", func() {
+		result := Render(10, 5, false, noStyles)
+		Expect(result).To(Equal("#files: 10 | #dirs: 5"))
+	})
+
+	It("treats a zero value as unset for counts", func() {
+		result := Render(0, 5, true, noStyles)
+		Expect(result).To(Equal("🐌 | #dirs: 5"))
+	})
+
+	It("applies LabelStyle to labels and ValueStyle to numeric values", func() {
+		labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("4"))
+		valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+		styles := Styles{
+			LabelStyle: labelStyle,
+			ValueStyle: valueStyle,
+		}
+		expect := labelStyle.Render("🐌") + " | " +
+			labelStyle.Render("#files") + ": " + valueStyle.Render("7") + " | " +
+			labelStyle.Render("#dirs") + ": " + valueStyle.Render("3")
+		result := Render(7, 3, true, styles)
+		Expect(result).To(Equal(expect))
+	})
+
+	It("applies LabelStyle to the 🐌 indicator (it has no value)", func() {
+		labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("4"))
+		styles := Styles{
+			LabelStyle: labelStyle,
+			ValueStyle: lipgloss.NewStyle(),
+		}
+		result := Render(0, 0, true, styles)
+		Expect(result).To(Equal(labelStyle.Render("🐌")))
+	})
+})


### PR DESCRIPTION
feat(prism): add flags row to highway view (#568)

feat(prism): fix dividers between flags (#568)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `flags-row-position` setting for highway view to control supplementary flags placement (top or bottom).
  * Introduced sampler widget display for sampling options.

* **UI/Display Improvements**
  * Refactored highway view header layout with improved filter and cascade information presentation.
  * Enhanced filter display with cleaner label-value formatting.
  * Improved flags row rendering with better visual organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->