### PR TITLE
feat(prism): add ansi shadow banner (#547)

### DIFF
--- a/src/app/bedrock/banner_test.go
+++ b/src/app/bedrock/banner_test.go
@@ -1,0 +1,82 @@
+package bedrock_test
+
+import (
+	"testing/fstest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/snivilised/jaywalk/src/app/bedrock"
+	"github.com/snivilised/jaywalk/src/locale"
+	"github.com/snivilised/li18ngo"
+	"github.com/snivilised/nefilim/test/luna"
+)
+
+var _ = Describe("BannerSubConfig loading", Ordered, func() {
+	BeforeAll(func() {
+		Expect(li18ngo.Use(
+			func(o *li18ngo.UseOptions) {
+				o.From.Sources = li18ngo.TranslationFiles{
+					locale.SourceID: li18ngo.TranslationSource{Name: "agenor"},
+				}
+			},
+		)).To(Succeed())
+	})
+
+	const configHome = "root/banner"
+
+	newLoader := func(yaml string) *bedrock.ViewConfigLoader {
+		fS := luna.NewMemFS()
+		fS.MapFS[configHome+"/jay.ui.yaml"] = &fstest.MapFile{
+			Data: []byte(yaml),
+		}
+		return bedrock.NewViewConfigLoaderWithFS(configHome, fS)
+	}
+
+	Describe("steps override", func() {
+		It("defaults Steps to zero when the section is absent", func() {
+			loader := newLoader(`
+ui:
+  highway: {}
+`)
+			var cfg bedrock.HighwayConfig
+			Expect(loader.Load("highway", &cfg)).To(Succeed())
+			Expect(cfg.Banner.Steps).To(Equal(0))
+		})
+
+		It("parses the steps override from jay.ui.yml", func() {
+			loader := newLoader(`
+ui:
+  highway:
+    banner:
+      position: bottom
+      tick: 100
+      steps: 48
+`)
+			var cfg bedrock.HighwayConfig
+			Expect(loader.Load("highway", &cfg)).To(Succeed())
+			Expect(cfg.Banner.Position).To(Equal("bottom"))
+			Expect(cfg.Banner.Tick).To(Equal(100))
+			Expect(cfg.Banner.Steps).To(Equal(48))
+		})
+
+		It("keeps the other banner settings intact when steps is set", func() {
+			loader := newLoader(`
+ui:
+  highway:
+    banner:
+      disable: false
+      position: top
+      tick: 250
+      justify: center
+      steps: 32
+`)
+			var cfg bedrock.HighwayConfig
+			Expect(loader.Load("highway", &cfg)).To(Succeed())
+			Expect(cfg.Banner.Disable).To(BeFalse())
+			Expect(cfg.Banner.Position).To(Equal("top"))
+			Expect(cfg.Banner.Tick).To(Equal(250))
+			Expect(cfg.Banner.Justify).To(Equal("center"))
+			Expect(cfg.Banner.Steps).To(Equal(32))
+		})
+	})
+})

--- a/src/app/bedrock/data/example.jay.ui.yml
+++ b/src/app/bedrock/data/example.jay.ui.yml
@@ -29,6 +29,21 @@ ui:
     # 'bottom' when omitted or set to an unrecognised value.
     flags-row-position: 'bottom'
 
+    # Banner settings. The banner is an ANSI-styled ASCII art rendered
+    # OUTSIDE the bordered region of the highway view, so its placement
+    # is independent of the flags row position above.
+    banner:
+      # When true, the banner is hidden. Defaults to false (shown).
+      disable: false
+      # 'top' = above the top border; 'bottom' = below the summary.
+      # Defaults to 'top' when omitted or unrecognised.
+      position: 'top'
+      # Per-tick interval (ms) for the banner's gradient animation.
+      # Larger values produce a slower, warmer glow. Defaults to 500.
+      tick: 500
+      # Horizontal alignment: 'right' (default), 'left' or 'center'.
+      justify: 'right'
+
     # Animation data configuration for Highway view lanes
     animation:
       # List of animation types to load on demand

--- a/src/app/bedrock/types.go
+++ b/src/app/bedrock/types.go
@@ -153,6 +153,45 @@ type HighwayConfig struct {
 	// line). Empty or invalid values default to "bottom" and a warning is
 	// logged at load time.
 	FlagsRowPosition string `mapstructure:"flags-row-position,omitempty"`
+
+	// Banner controls the ANSI shadow banner rendered outside the highway
+	// view's bordered region. The banner can be disabled, placed above
+	// or below the border, and tuned with a per-tick gradient animation
+	// interval. The colour sweep itself is resolved from the theme via
+	// highlights.components["banner-control"].
+	Banner BannerSubConfig `mapstructure:"banner,omitempty"`
+}
+
+// BannerSubConfig holds the raw, on-disk shape of the banner settings
+// loaded from jay.ui.yml. The resolved (palette-aware) shape lives in
+// ui.BannerConfig - see ui/registry.go.
+type BannerSubConfig struct {
+	// Disable hides the banner when true. Defaults to false (shown).
+	Disable bool `mapstructure:"disable"`
+
+	// Position controls where the banner is rendered relative to the
+	// bordered region. "top" places it above the top border; "bottom"
+	// places it below the bottom border. Empty or unrecognised values
+	// default to "top" with a warning logged at load time.
+	Position string `mapstructure:"position,omitempty"`
+
+	// Tick is the per-tick interval in milliseconds for the banner's
+	// gradient animation. Larger values produce a slower, warmer glow.
+	// Zero or omitted resolves to banner.DefaultBannerTick (500ms).
+	Tick int `mapstructure:"tick,omitempty"`
+
+	// Justify controls the horizontal alignment of the banner within
+	// the terminal. Allowed values: "right" (default), "left",
+	// "center". Empty or unrecognised values default to "right".
+	Justify string `mapstructure:"justify,omitempty"`
+
+	// Steps overrides the number of interpolated colour steps used
+	// for the banner's gradient sweep. The banner normally inherits
+	// the steps count from the gradient defined in the theme. Setting
+	// this field lets the user produce a smoother or more abrupt
+	// colour sweep on the banner only, without redefining the shared
+	// gradient. Zero or omitted means "use the gradient's own steps".
+	Steps int `mapstructure:"steps,omitempty"`
 }
 
 // HighwayAnimationConfig holds animation data configuration for Highway view.

--- a/src/app/command/bootstrap.go
+++ b/src/app/command/bootstrap.go
@@ -239,8 +239,7 @@ func (b *Bootstrap) Root(options ...ConfigureAppOptionFn) *cobra.Command {
 				// Bootstrap is view-agnostic. The polymorphic
 				// ui.LoadConfig returns the ViewConfig that
 				// corresponds to the selected mode; ui.New consumes
-				// it. The two calls together replace the per-view
-				// branching that used to live here.
+				// it.
 				palette, err := b.themeLoader.Load(b.rootPs.Native.Theme)
 				if err != nil {
 					return err

--- a/src/app/ui/banner_test.go
+++ b/src/app/ui/banner_test.go
@@ -1,0 +1,151 @@
+package ui
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/jaywalk/src/app/bedrock"
+	"github.com/snivilised/jaywalk/src/prism/contract"
+)
+
+var _ = Describe("resolveBannerConfig", func() {
+	When("a steps override is provided", func() {
+		It("propagates the override to the resolved config", func() {
+			raw := bedrock.BannerSubConfig{
+				Position: bannerPositionBottom,
+				Tick:     100,
+				Steps:    48,
+			}
+
+			cfg := resolveBannerConfig(raw, contract.Palette{})
+
+			Expect(cfg.Position).To(Equal(bannerPositionBottom))
+			Expect(cfg.Tick).To(Equal(100))
+			Expect(cfg.StepsOverride).To(Equal(48))
+		})
+	})
+
+	When("the steps override is omitted", func() {
+		It("leaves StepsOverride as zero so the gradient's own steps are used", func() {
+			raw := bedrock.BannerSubConfig{
+				Position: bannerPositionTop,
+			}
+
+			cfg := resolveBannerConfig(raw, contract.Palette{})
+
+			Expect(cfg.StepsOverride).To(Equal(0))
+		})
+
+		It("treats a negative value the same as zero", func() {
+			raw := bedrock.BannerSubConfig{Steps: -5}
+
+			cfg := resolveBannerConfig(raw, contract.Palette{})
+
+			Expect(cfg.StepsOverride).To(Equal(0))
+		})
+	})
+
+	When("the banner is disabled", func() {
+		It("still preserves the steps override", func() {
+			raw := bedrock.BannerSubConfig{
+				Disable: true,
+				Steps:   24,
+			}
+
+			cfg := resolveBannerConfig(raw, contract.Palette{})
+
+			Expect(cfg.Disable).To(BeTrue())
+			Expect(cfg.StepsOverride).To(Equal(24))
+		})
+	})
+})
+
+// bannerGradientPalette returns a Palette with a banner-control
+// component bound to a small named gradient. The gradient has 4 steps
+// by default so the tests can distinguish "no override" (4 steps) from
+// "override applied" (e.g. 48 steps).
+func bannerGradientPalette() contract.Palette {
+	return contract.Palette{
+		Highlights: contract.HighlightsConfig{
+			Gradients: map[string]contract.GradientDef{
+				"banner-gradient": {
+					Steps: 4,
+					Hi:    &contract.SemanticColour{ANSI16: "cyan", TrueColor: "#00E5FF"},
+					Lo:    &contract.SemanticColour{ANSI16: "magenta", TrueColor: "#B388FF"},
+				},
+			},
+			Components: map[string]string{
+				contract.GradientComponentBanner: "banner-gradient",
+			},
+		},
+	}
+}
+
+// newBannerPresenter constructs a highwayPresenter with the supplied
+// banner config. The palette is wired up so the banner-control
+// component resolves to a real gradient.
+func newBannerPresenter(bannerCfg BannerConfig) *highwayPresenter {
+	theme, err := contract.NewTheme(bannerGradientPalette(), &bytes.Buffer{})
+	Expect(err).NotTo(HaveOccurred())
+
+	return &highwayPresenter{
+		cfg: HighwayConfig{
+			Banner: bannerCfg,
+		},
+		theme: theme,
+	}
+}
+
+var _ = Describe("buildBannerInfo - steps override", func() {
+	It("uses the gradient's own steps when no override is configured", func() {
+		h := newBannerPresenter(BannerConfig{
+			Position: bannerPositionTop,
+		})
+
+		info := h.buildBannerInfo()
+
+		Expect(info.Gradient).NotTo(BeNil())
+		Expect(info.Gradient.Steps).To(Equal(4))
+	})
+
+	It("applies the override when the user sets steps in the UI config", func() {
+		h := newBannerPresenter(BannerConfig{
+			Position:      bannerPositionTop,
+			StepsOverride: 48,
+		})
+
+		info := h.buildBannerInfo()
+
+		Expect(info.Gradient).NotTo(BeNil())
+		Expect(info.Gradient.Steps).To(Equal(48))
+	})
+
+	It("uses the override rather than the gradient's Hi/Lo endpoints", func() {
+		h := newBannerPresenter(BannerConfig{
+			Position:      bannerPositionTop,
+			StepsOverride: 16,
+		})
+
+		info := h.buildBannerInfo()
+
+		// Steps change but the colours are still inherited from
+		// the shared gradient.
+		Expect(info.Gradient.Steps).To(Equal(16))
+		Expect(info.Gradient.Hi).NotTo(BeNil())
+		Expect(info.Gradient.Lo).NotTo(BeNil())
+	})
+
+	It("leaves the gradient state at the override value", func() {
+		h := newBannerPresenter(BannerConfig{
+			Position:      bannerPositionTop,
+			StepsOverride: 32,
+		})
+
+		info := h.buildBannerInfo()
+
+		Expect(info.State).NotTo(BeNil())
+		Expect(info.State.TotalSteps).To(Equal(32))
+	})
+})

--- a/src/app/ui/highway-defs.go
+++ b/src/app/ui/highway-defs.go
@@ -6,6 +6,13 @@ import "time"
 const (
 	defaultLaneCount = 4
 	highwayTickRate  = 50 * time.Millisecond
+
+	// bannerDefaultTickMs is the fallback tick interval (ms) for
+	// the banner's gradient animation. Users can override via
+	// ui.highway.banner.tick. The value is in milliseconds to match
+	// the underlying config field; the model converts to
+	// time.Duration on receipt.
+	bannerDefaultTickMs = 500
 )
 
 var (

--- a/src/app/ui/highway.go
+++ b/src/app/ui/highway.go
@@ -5,6 +5,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/snivilised/jaywalk/src/agenor/core"
@@ -12,8 +13,10 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/app/report"
 	"github.com/snivilised/jaywalk/src/prism/contract"
+	"github.com/snivilised/jaywalk/src/prism/effects"
 	"github.com/snivilised/jaywalk/src/prism/highway"
 	"github.com/snivilised/jaywalk/src/prism/movies"
+	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
 )
 
 // HighwayConfig is declared in registry.go alongside the other view
@@ -39,6 +42,11 @@ type highwayPresenter struct {
 
 	// Job emoji pool state - populated from config, random emoji picked per job arrival.
 	jobEmojiPool []string
+
+	// bannerInfo is built once in OnBegin and sent to the model via
+	// OvertureMsg. It carries the random aspects and gradient
+	// endpoints resolved from the theme.
+	bannerInfo highway.BannerInfo
 }
 
 func newHighwayPresenter(palette contract.Palette, hCfg HighwayConfig) (report.Presenter, error) {
@@ -99,6 +107,10 @@ func (h *highwayPresenter) OnBegin(e *report.BeginEvent) {
 	// at the flag-binding layer, so only one of 🔒/depth can be present.
 	h.noRecurse = strings.Contains(h.header.CascadeDisplay, contract.Static.Emoji.Padlock)
 
+	// Build the banner info once at startup. The random aspects are
+	// frozen here so the banner reads the same on every render.
+	h.bannerInfo = h.buildBannerInfo()
+
 	lanes := BuildHighwayLanes(h.cfg, h.noW)
 	model := highway.NewModel(lanes, highwayTickRate, e.Root, h.maxDepth, h.theme, h.noRecurse)
 	h.program = tea.NewProgram(model)
@@ -138,6 +150,11 @@ func (h *highwayPresenter) OnBegin(e *report.BeginEvent) {
 
 		// Position of the flags row
 		FlagsRowPosition: h.cfg.FlagsRowPosition,
+
+		// Banner info populated once in OnBegin. The model receives
+		// the gradient state pointer and advances it on every banner
+		// tick.
+		Banner: h.bannerInfo,
 	})
 
 	if h.totalFiles > 0 || h.totalDirs > 0 {
@@ -309,4 +326,74 @@ func BuildHighwayLanes(cfg HighwayConfig, now uint) []highway.Lane {
 		}
 	}
 	return lanes
+}
+
+// buildBannerInfo assembles the per-session BannerInfo for the highway
+// model. The random aspect selection is performed exactly once here
+// (math/rand/v2, package-level source) so the aspects are frozen for
+// the duration of the process. The gradient endpoints are resolved
+// from the theme's "banner-control" component, falling back to no
+// gradient (which causes the widget to render as plain text) when
+// the binding is absent.
+//
+// When the user has disabled the banner, the returned BannerInfo has
+// Disable=true and the gradient/state pointers are nil. The highway
+// model treats this as "do not render".
+func (h *highwayPresenter) buildBannerInfo() highway.BannerInfo {
+	info := highway.BannerInfo{
+		Disable:  h.cfg.Banner.Disable,
+		Position: h.cfg.Banner.Position,
+		Justify:  h.cfg.Banner.Justify,
+	}
+
+	if h.cfg.Banner.Disable {
+		return info
+	}
+
+	// Resolve the gradient from the theme. The "banner-control"
+	// component must be bound to a gradient in the theme YAML;
+	// when missing the banner renders as plain text.
+	//
+	// StepsOverride (from ui.highway.banner.steps) lets the user
+	// keep sharing the gradient's colour endpoints with other
+	// widgets (so the colour scheme stays consistent) but tune
+	// the banner's sweep smoothness independently. Zero means
+	// "use the gradient's own steps".
+	var grad *contract.ResolvedGradient
+	if g, ok := h.theme.GradientFor(contract.GradientComponentBanner); ok && g.Steps > 0 {
+		steps := g.Steps
+		if h.cfg.Banner.StepsOverride > 0 {
+			steps = h.cfg.Banner.StepsOverride
+		}
+		grad = &contract.ResolvedGradient{Steps: steps, Hi: g.Hi, Lo: g.Lo}
+	}
+	info.Gradient = grad
+
+	if grad != nil {
+		st := effects.NewGradientState()
+		st.TotalSteps = grad.Steps
+		info.State = st
+	}
+
+	// Pick the random aspects ONCE here, not per-render. Use the
+	// package-level random source (math/rand/v2) which is fine for
+	// non-security purposes.
+	rng := rand.New(rand.NewPCG(uint64(os.Getpid()), uint64(core.Now().UnixNano()))) //nolint:gosec // non-security
+	aspects := banner.RandomiseAspects(rng)
+	info.Aspects = highway.BannerAspects{
+		Orientation: int(aspects.Orientation),
+		Banding:     int(aspects.Banding),
+		Unity:       int(aspects.Unity),
+		FixedEnd:    int(aspects.FixedEnd),
+	}
+
+	// Resolve the per-tick interval. Tick in the config is in
+	// milliseconds; the model uses a time.Duration.
+	tick := h.cfg.Banner.Tick
+	if tick <= 0 {
+		tick = bannerDefaultTickMs
+	}
+	info.Tick = time.Duration(tick) * time.Millisecond
+
+	return info
 }

--- a/src/app/ui/registry.go
+++ b/src/app/ui/registry.go
@@ -48,6 +48,50 @@ const (
 )
 
 // ---------------------------------------------------------------------------
+// Banner position / justify / tick
+//
+// The banner is rendered OUTSIDE the bordered region of the highway
+// view, so it does not interact with the flags row placement.
+// ---------------------------------------------------------------------------
+
+const (
+	// bannerPositionTop places the banner above the top border.
+	bannerPositionTop = "top"
+
+	// bannerPositionBottom places the banner below the bottom border
+	// (after the summary).
+	bannerPositionBottom = "bottom"
+
+	// bannerPositionDefault is the value used when the configured
+	// value is empty or unrecognised.
+	bannerPositionDefault = bannerPositionTop
+)
+
+const (
+	// bannerJustifyRight aligns the right edge of every banner line
+	// with the right edge of the terminal.
+	bannerJustifyRight = "right"
+
+	// bannerJustifyLeft renders the banner flush against the left
+	// edge of the host view.
+	bannerJustifyLeft = "left"
+
+	// bannerJustifyCenter centres every banner line within the
+	// terminal.
+	bannerJustifyCenter = "center"
+
+	// bannerJustifyDefault is the value used when the configured
+	// value is empty or unrecognised.
+	bannerJustifyDefault = bannerJustifyRight
+)
+
+// bannerTickDefaultMs is the fallback per-tick interval for the
+// banner's gradient animation when the user has not configured one.
+// It deliberately matches banner.DefaultBannerTick (500ms) so the
+// hot-path here does not import the widget package.
+const bannerTickDefaultMs = 500
+
+// ---------------------------------------------------------------------------
 // Polymorphic view configuration
 // ---------------------------------------------------------------------------
 //
@@ -119,6 +163,48 @@ type HighwayConfig struct {
 	// an unrecognised value is normalised to "bottom" at load time
 	// (see loadHighwayConfig).
 	FlagsRowPosition string
+
+	// Banner controls the ANSI shadow banner rendered outside the
+	// highway view's bordered region. The colour sweep is resolved
+	// from the theme via highlights.components["banner-control"].
+	Banner BannerConfig
+}
+
+// BannerConfig is the resolved (palette-aware) shape of the banner
+// settings. The raw, on-disk shape is bedrock.BannerSubConfig; the
+// loader translates between the two.
+type BannerConfig struct {
+	// Disable hides the banner when true. Defaults to false.
+	Disable bool
+
+	// Position is the normalised banner position relative to the
+	// bordered region: "top" (above top border) or "bottom" (below
+	// bottom border). Always one of the two - the loader
+	// normalises empty/unknown values to "top".
+	Position string
+
+	// Tick is the per-tick interval in milliseconds for the
+	// banner's gradient animation. Zero resolves to
+	// banner.DefaultBannerTick (500ms).
+	Tick int
+
+	// Justify is the normalised horizontal alignment of the banner:
+	// "right" (default), "left" or "center". The loader normalises
+	// empty/unknown values to "right".
+	Justify string
+
+	// GradientName is the name of the gradient (from
+	// palette.highlights.gradients) bound to the
+	// "banner-control" component. Empty when no binding exists; the
+	// banner will then render as plain text.
+	GradientName string
+
+	// StepsOverride replaces the steps count of the gradient bound
+	// to the banner. Zero means "use the gradient's own steps". This
+	// lets the user share a gradient definition with other widgets
+	// (so they keep a common colour scheme) but tune the banner's
+	// smoothness/abruptness of the colour sweep independently.
+	StepsOverride int
 }
 
 // isViewConfig seals the implementation set.
@@ -181,6 +267,7 @@ func loadHighwayConfig(source ViewConfigSource, palette contract.Palette) (ViewC
 	}
 
 	flagsRowPosition := normaliseFlagsRowPosition(raw.FlagsRowPosition)
+	bannerCfg := resolveBannerConfig(raw.Banner, palette)
 
 	return HighwayConfig{
 		WorkerPool:        raw.WorkerPool,
@@ -190,6 +277,7 @@ func loadHighwayConfig(source ViewConfigSource, palette contract.Palette) (ViewC
 		AnimationGradient: nameFromPalette(palette, contract.GradientComponentActivity),
 		Overrides:         overrides,
 		FlagsRowPosition:  flagsRowPosition,
+		Banner:            bannerCfg,
 	}, nil
 }
 
@@ -211,6 +299,84 @@ func normaliseFlagsRowPosition(raw string) string {
 			raw, flagsRowPositionDefault,
 		)
 		return flagsRowPositionDefault
+	}
+}
+
+// resolveBannerConfig translates the raw banner sub-config (from
+// jay.ui.yml) into a resolved BannerConfig with normalised values and
+// a palette-derived gradient name. Unrecognised values are tolerated
+// with a stderr warning - the application never aborts because of a
+// banner misconfiguration, since the banner is a decorative element.
+func resolveBannerConfig(raw bedrock.BannerSubConfig, palette contract.Palette) BannerConfig {
+	return BannerConfig{
+		Disable:       raw.Disable,
+		Position:      normaliseBannerPosition(raw.Position),
+		Tick:          normaliseBannerTick(raw.Tick),
+		Justify:       normaliseBannerJustify(raw.Justify),
+		GradientName:  nameFromPalette(palette, contract.GradientComponentBanner),
+		StepsOverride: normaliseBannerSteps(raw.Steps),
+	}
+}
+
+// normaliseBannerPosition validates the configured banner position.
+// Empty values default to "top". Unrecognised values also default to
+// "top" with a warning to stderr.
+func normaliseBannerPosition(raw string) string {
+	if raw == "" {
+		return bannerPositionDefault
+	}
+
+	switch raw {
+	case bannerPositionTop, bannerPositionBottom:
+		return raw
+	default:
+		fmt.Fprintf(os.Stderr,
+			"warning: ui.highway.banner.position: unrecognised value %q, defaulting to %q\n",
+			raw, bannerPositionDefault,
+		)
+		return bannerPositionDefault
+	}
+}
+
+// normaliseBannerTick substitutes the package default when the
+// configured value is zero. Negative values are treated as zero.
+func normaliseBannerTick(raw int) int {
+	if raw <= 0 {
+		return bannerTickDefaultMs
+	}
+	return raw
+}
+
+// normaliseBannerSteps passes through the user-supplied steps count
+// after clamping non-positive values to zero. Zero is the sentinel
+// meaning "no override; use the gradient's own steps" (see
+// BannerConfig.StepsOverride). The interpolation routine enforces a
+// minimum of 2 internally, so a stray value of 1 will resolve to 2
+// steps at render time without surfacing as a configuration error.
+func normaliseBannerSteps(raw int) int {
+	if raw <= 0 {
+		return 0
+	}
+	return raw
+}
+
+// normaliseBannerJustify validates the configured justify value. Empty
+// values default to "right". Unrecognised values also default to
+// "right" with a warning to stderr.
+func normaliseBannerJustify(raw string) string {
+	if raw == "" {
+		return bannerJustifyDefault
+	}
+
+	switch raw {
+	case bannerJustifyRight, bannerJustifyLeft, bannerJustifyCenter:
+		return raw
+	default:
+		fmt.Fprintf(os.Stderr,
+			"warning: ui.highway.banner.justify: unrecognised value %q, defaulting to %q\n",
+			raw, bannerJustifyDefault,
+		)
+		return bannerJustifyDefault
 	}
 }
 

--- a/src/prism/contract/palette.go
+++ b/src/prism/contract/palette.go
@@ -162,6 +162,11 @@ const (
 
 	// GradientComponentLandingStrip is the execution info at the lane end.
 	GradientComponentLandingStrip = "landing-strip-control"
+
+	// GradientComponentBanner is the ANSI shadow banner widget.
+	// Themes bind this component to a gradient name to control the
+	// colour sweep of the banner's face/shadow characters.
+	GradientComponentBanner = "banner-control"
 )
 
 // deriveDimmed returns a colour approximately halfway between the given

--- a/src/prism/effects/gradient-state.go
+++ b/src/prism/effects/gradient-state.go
@@ -64,20 +64,37 @@ func (s *GradientState) Reset() {
 }
 
 // GetEffectiveIndex returns the gradient index for character at position pos.
-// Uses modular wrapping so the gradient scrolls through the content rather
-// than clamping to the last colour. The Offset acts as a phase shift that
-// advances each tick via Update(), creating a pulsing sweep effect.
+//
+// The offset is treated as the phase of a triangle wave whose period
+// is 2 * (n - 1). The phase for this rune is (offset + pos); mapped
+// into the gradient index space this means:
+//
+//	phase 0..n-1        → index 0..n-1       (forward sweep)
+//	phase n..2*(n-1)    → index n-2..0       (reverse sweep)
+//
+// This produces a smooth Hi → Lo → Hi ping-pong with no sharp
+// wrap-around at the boundary (which would otherwise be a hard
+// jump from step[n-1] back to step[0]). The pos argument is a
+// per-rune phase shift that lets the gradient scroll across the
+// content while preserving the bounce.
 func (s *GradientState) GetEffectiveIndex(pos int) int {
-	if len(s.stepsArray) == 0 {
+	n := len(s.stepsArray)
+	if n == 0 {
 		return -1
 	}
-
-	idx := (s.Offset + pos) % len(s.stepsArray)
-	if idx < 0 {
-		idx += len(s.stepsArray)
+	if n == 1 {
+		return 0
 	}
 
-	return idx
+	period := 2 * (n - 1)
+	phase := (s.Offset + pos) % period
+	if phase < 0 {
+		phase += period
+	}
+	if phase < n {
+		return phase
+	}
+	return period - phase
 }
 
 // ApplyGradient applies a colour gradient from Hi to Lo across an animation frame.

--- a/src/prism/effects/gradient-state_test.go
+++ b/src/prism/effects/gradient-state_test.go
@@ -69,6 +69,47 @@ var _ = Describe("Highway Gradient Rendering", func() {
 			Expect(idx).To(BeNumerically("<=", 3))
 			Expect(idx).To(BeNumerically(">=", 0))
 		})
+
+		It("GetEffectiveIndex produces a smooth ping-pong (no wrap-around sharp jumps)", func() {
+			state := NewGradientState()
+			steps := []contract.Colour{
+				{R: 255, G: 0, B: 0},   // 0: Hi (red)
+				{R: 170, G: 0, B: 85},  // 1
+				{R: 85, G: 0, B: 170},  // 2
+				{R: 0, G: 0, B: 255},   // 3: Lo (blue)
+			}
+			state.SetSteps(steps)
+
+			// For pos=0, the phase is just the offset (0,1,2,3,2,1,0,1,2,3,...)
+			// so the index sequence is 0,1,2,3,2,1,0,1,2,3,...
+			// Each transition is between adjacent gradient steps; the
+			// wrap from step[3] back to step[0] does NOT occur at
+			// pos=0 because the triangle wave handles it.
+			pos := 0
+			got := []int{}
+			for tick := 0; tick < 8; tick++ {
+				got = append(got, state.GetEffectiveIndex(pos))
+				state.Update(1)
+			}
+			Expect(got).To(Equal([]int{0, 1, 2, 3, 2, 1, 0, 1}))
+
+			// For pos=1, the phase is offset+1 (1,2,3,4,3,2,1,2,...).
+			// Mapped through the triangle wave:
+			//   phase 1→1, 2→2, 3→3, 4→2 (period-phase=2),
+			//   3→3, 2→2, 1→1, 2→2
+			// So the index sequence is 1,2,3,2,3,2,1,2.
+			// Critically, the transition from 3→2 is adjacent (no
+			// wrap to 0) and 2→3 is adjacent.
+			state = NewGradientState()
+			state.SetSteps(steps)
+			pos = 1
+			got = []int{}
+			for tick := 0; tick < 8; tick++ {
+				got = append(got, state.GetEffectiveIndex(pos))
+				state.Update(1)
+			}
+			Expect(got).To(Equal([]int{1, 2, 3, 2, 3, 2, 1, 2}))
+		})
 	})
 
 	Context("ANSI Formatting", func() {

--- a/src/prism/highway/banner-state.go
+++ b/src/prism/highway/banner-state.go
@@ -1,0 +1,65 @@
+package highway
+
+import (
+	"time"
+
+	"github.com/snivilised/jaywalk/src/prism/effects"
+)
+
+// bannerState holds the per-render state of the ANSI shadow banner.
+// The GradientState is the same primitive that the lane animations
+// use (see effects/gradient-state.go). The skipCounter advances one
+// step every tickRate/bannerTick global ticks, producing a slower,
+// warmer glow than the lane animations.
+type bannerState struct {
+	gradient    *effects.GradientState
+	skipCounter int
+	skipFactor  int
+	tick        time.Duration
+}
+
+// newBannerState constructs a bannerState from the supplied gradient
+// state and per-tick interval. skipFactor is computed from the
+// global tickRate (passed in) and the banner's own tick. A skipFactor
+// of 0 means the banner advances on every global tick (full speed);
+// larger values mean it advances less often (slower glow).
+func newBannerState(gs *effects.GradientState, bannerTick, globalTick time.Duration) *bannerState {
+	if gs == nil {
+		return nil
+	}
+	if bannerTick <= 0 {
+		bannerTick = 500 * time.Millisecond
+	}
+	factor := 0
+	if globalTick > 0 {
+		ns := bannerTick.Nanoseconds() / globalTick.Nanoseconds()
+		if ns > 0 {
+			factor = int(ns)
+		}
+	}
+	return &bannerState{
+		gradient:    gs,
+		skipFactor:  factor,
+		tick:        bannerTick,
+		skipCounter: 0,
+	}
+}
+
+// advance should be called on every global tick. It increments the
+// skipCounter and, when the threshold is reached, advances the
+// gradient state by one step. The advance uses a windowSize of 1
+// (one rune column at a time) so the sweep is gentle.
+func (b *bannerState) advance() {
+	if b == nil || b.gradient == nil {
+		return
+	}
+	if b.skipFactor <= 0 {
+		b.gradient.Update(1)
+		return
+	}
+	b.skipCounter++
+	if b.skipCounter >= b.skipFactor {
+		b.skipCounter = 0
+		b.gradient.Update(1)
+	}
+}

--- a/src/prism/highway/banner_test.go
+++ b/src/prism/highway/banner_test.go
@@ -1,0 +1,187 @@
+//go:build !race
+// +build !race
+
+package highway
+
+import (
+	"image/color"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+	"github.com/snivilised/jaywalk/src/prism/effects"
+)
+
+// viewContent extracts the rendered string from the model's view.
+// The Model's View() method returns a tea.View whose string content
+// is what we assert on in the tests below.
+func viewContent(m Model) string {
+	v := m.View()
+	return v.Content
+}
+
+// bannerTestGradient returns a small fixed gradient suitable for
+// banner integration tests. Hi is red, Lo is blue, 4 steps.
+func bannerTestGradient() *contract.ResolvedGradient {
+	return &contract.ResolvedGradient{
+		Steps: 4,
+		Hi:    color.RGBA{R: 255, G: 0, B: 0, A: 255},
+		Lo:    color.RGBA{R: 0, G: 0, B: 255, A: 255},
+	}
+}
+
+// makeBannerInfo builds a BannerInfo that the highway model will
+// accept (i.e. a non-nil Gradient and State).
+func makeBannerInfo(position string) BannerInfo {
+	grad := bannerTestGradient()
+	st := effects.NewGradientState()
+	hiR, hiG, hiB, _ := grad.Hi.RGBA()
+	loR, loG, loB, _ := grad.Lo.RGBA()
+	steps := effects.InterpolateBetweenRGBA(
+		uint8(hiR>>8), uint8(hiG>>8), uint8(hiB>>8), //nolint:gosec // safe: 16-bit value >> 8 fits in 8 bits
+		uint8(loR>>8), uint8(loG>>8), uint8(loB>>8), //nolint:gosec // safe: 16-bit value >> 8 fits in 8 bits
+		grad.Steps,
+	)
+	st.SetSteps(steps)
+	return BannerInfo{
+		Disable:  false,
+		Position: position,
+		Justify:  "right",
+		Width:    60,
+		Gradient: grad,
+		State:    st,
+		Tick:     500 * time.Millisecond,
+	}
+}
+
+var _ = Describe("Banner integration with highway view", func() {
+	Describe("rendering position", func() {
+		It("renders the banner above the top border when Position = top", func() {
+			m := baseModel(1)
+			info := makeBannerInfo(BannerPositionTop)
+			updated, _ := update(m, OvertureMsg{
+				FlagsRowPosition: FlagsRowPositionBottom,
+				Banner:           info,
+			})
+			out := viewContent(updated)
+
+			// The banner widget's first line is the art (which the
+			// highway does not pre-populate - the widget renders
+			// the art from the gradient/state). The art contains
+			// face runes (█); the rendered output is the ANSI-
+			// styled art followed by the bordered region.
+			// The very first non-empty line must contain a face
+			// rune or the banner's leading whitespace, not the
+			// top border (which is rendered with border characters).
+			lines := strings.Split(out, "\n")
+			Expect(lines).NotTo(BeEmpty())
+
+			// Top border: the highway's renderHeader starts with
+			// ╭─ (rounded) or ┌─ (square) depending on theme. The
+			// first line should NOT be the top border - it should
+			// be the banner. We look for ANSI colour sequences
+			// in the first line (the banner always emits them).
+			first := lines[0]
+			Expect(strings.Contains(first, "\x1b[38;2;")).To(BeTrue(),
+				"first line should contain ANSI colour sequences from the banner")
+
+			// The top border (rounded ╭ or square ┌) should appear
+			// in the output, but NOT on the first line.
+			combined := strings.Join(lines[1:], "\n")
+			Expect(combined).To(SatisfyAny(
+				ContainSubstring("╭"),
+				ContainSubstring("┌"),
+			))
+		})
+
+		It("renders the banner below the bottom border when Position = bottom", func() {
+			m := baseModel(1)
+			info := makeBannerInfo(BannerPositionBottom)
+			updated, _ := update(m, OvertureMsg{
+				FlagsRowPosition: FlagsRowPositionBottom,
+				Banner:           info,
+			})
+			out := viewContent(updated)
+			lines := strings.Split(out, "\n")
+
+			// The last non-empty line should contain the banner
+			// output (ANSI colour sequences). The bottom border
+			// (rounded ╰ or square └) appears earlier in the output.
+			// The output may end with a trailing newline (producing
+			// an empty last line); we therefore skip trailing empty
+			// lines when locating the banner line.
+			Expect(lines).NotTo(BeEmpty())
+			lastIdx := len(lines) - 1
+			for lastIdx > 0 && strings.TrimSpace(lines[lastIdx]) == "" {
+				lastIdx--
+			}
+			last := lines[lastIdx]
+			Expect(strings.Contains(last, "\x1b[38;2;")).To(BeTrue(),
+				"last non-empty line should contain ANSI colour sequences from the banner")
+
+			// The bottom border should appear before the last
+			// non-empty line.
+			combined := strings.Join(lines[:lastIdx], "\n")
+			Expect(combined).To(SatisfyAny(
+				ContainSubstring("╰"),
+				ContainSubstring("└"),
+			))
+		})
+
+		It("skips the banner when Disable = true", func() {
+			m := baseModel(1)
+			info := makeBannerInfo(BannerPositionTop)
+			info.Disable = true
+			updated, _ := update(m, OvertureMsg{
+				FlagsRowPosition: FlagsRowPositionBottom,
+				Banner:           info,
+			})
+			out := viewContent(updated)
+			// The view should not contain the banner's ANSI codes.
+			Expect(strings.Contains(out, "\x1b[38;2;")).To(BeFalse())
+		})
+	})
+
+	Describe("animation tick", func() {
+		It("advances the banner's gradient state on every global tick (skipFactor=0)", func() {
+			m := baseModel(1)
+			info := makeBannerInfo(BannerPositionTop)
+			updated, _ := update(m, OvertureMsg{
+				FlagsRowPosition: FlagsRowPositionBottom,
+				Banner:           info,
+			})
+
+			before := updated.banner.gradient.Offset
+			// Drive a single tick through the model.
+			updated, _ = update(updated, tickMsg(time.Now()))
+			after := updated.banner.gradient.Offset
+
+			// 50ms global tick / 500ms banner tick = 10 → skipFactor=10
+			// One tick is not enough to advance.
+			// We assert the gradient state was created.
+			Expect(updated.banner).NotTo(BeNil())
+			Expect(updated.banner.skipFactor).To(Equal(10))
+			_ = before
+			_ = after
+		})
+
+		It("advances the gradient state after skipFactor ticks", func() {
+			m := baseModel(1)
+			info := makeBannerInfo(BannerPositionTop)
+			updated, _ := update(m, OvertureMsg{
+				FlagsRowPosition: FlagsRowPositionBottom,
+				Banner:           info,
+			})
+			before := updated.banner.gradient.Offset
+			// 10 ticks (skipFactor) → 1 advance.
+			for i := 0; i < 10; i++ {
+				updated, _ = update(updated, tickMsg(time.Now()))
+			}
+			after := updated.banner.gradient.Offset
+			Expect(after).To(Equal(before + 1))
+		})
+	})
+})

--- a/src/prism/highway/highway-defs.go
+++ b/src/prism/highway/highway-defs.go
@@ -21,3 +21,15 @@ const (
 	// status line and below the last highway lane (the default).
 	FlagsRowPositionBottom = "bottom"
 )
+
+// Banner position - mirrors ui bannerPosition*. The banner is rendered
+// OUTSIDE the bordered region of the highway view, so these values do
+// not interact with the flags row placement above.
+const (
+	// BannerPositionTop places the banner above the top border.
+	BannerPositionTop = "top"
+
+	// BannerPositionBottom places the banner below the bottom border
+	// (after the summary).
+	BannerPositionBottom = "bottom"
+)

--- a/src/prism/highway/messages.go
+++ b/src/prism/highway/messages.go
@@ -4,7 +4,60 @@ import (
 	"time"
 
 	"github.com/snivilised/jaywalk/src/prism/contract"
+	"github.com/snivilised/jaywalk/src/prism/effects"
 )
+
+// BannerInfo is the per-render state for the ANSI shadow banner. The
+// presenter populates one of these in OnBegin (picking the random
+// aspects once) and sends it via OvertureMsg. The model then drives
+// the gradient state on every tick and renders the banner above or
+// below the bordered region of the highway view.
+type BannerInfo struct {
+	// Disable hides the banner when true. The widget is still
+	// constructed but the view skips it.
+	Disable bool
+
+	// Position selects whether the banner is rendered above the top
+	// border ("top") or below the bottom border ("bottom"). The view
+	// treats any other value as "top".
+	Position string
+
+	// Justify is the horizontal alignment of the banner: "right",
+	// "left" or "center". The widget handles all three.
+	Justify string
+
+	// Width is the terminal width. The widget uses it for
+	// justification padding.
+	Width int
+
+	// Aspects are the random visual aspects chosen once at startup.
+	// See banner.Aspects for the orthogonal values.
+	Aspects BannerAspects
+
+	// Gradient is the resolved colour endpoints (Hi/Lo) bound to
+	// the "banner-control" theme component.
+	Gradient *contract.ResolvedGradient
+
+	// State is the per-widget gradient state advanced on each
+	// banner tick. The highway model owns the lifecycle of this
+	// pointer.
+	State *effects.GradientState
+
+	// Tick is the per-tick interval in milliseconds for the banner's
+	// gradient animation. The model uses this to compute the skip
+	// factor relative to the global tick rate.
+	Tick time.Duration
+}
+
+// BannerAspects is the subset of banner.Aspects the highway model
+// needs. The full type lives in the banner package; this is the
+// pre-computed view produced by the presenter.
+type BannerAspects struct {
+	Orientation int
+	Banding     int
+	Unity       int
+	FixedEnd    int
+}
 
 type OvertureMsg struct {
 	Root              string
@@ -23,6 +76,10 @@ type OvertureMsg struct {
 	// values are "top" and "bottom"; any other value is treated as
 	// "bottom" (the default).
 	FlagsRowPosition string
+
+	// Banner carries the optional ANSI shadow banner info. When the
+	// Disable flag is true or the gradient is nil, the view skips it.
+	Banner BannerInfo
 }
 
 type MotifData struct {

--- a/src/prism/highway/model.go
+++ b/src/prism/highway/model.go
@@ -54,6 +54,15 @@ type Model struct {
 	// border, "bottom" places it above the status line. The default
 	// applied by the loader is "bottom".
 	FlagsRowPosition string
+
+	// banner is the per-render state for the optional ANSI shadow
+	// banner. Nil when the banner is disabled. The gradient state
+	// advances on a slower tick than the lane animations.
+	banner *bannerState
+
+	// bannerInfo is the (immutable for the session) configuration
+	// received via OvertureMsg. The view reads this each render.
+	bannerInfo BannerInfo
 }
 
 // initLaneSkip computes the per-lane skip factor from each lane's
@@ -165,6 +174,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.lanes[i].PeriscopeGradientState.Update(windowSize)
 			}
 		}
+
+		// Advance the banner's gradient state on its own slower tick
+		// so its warm glow is visibly different from the lane
+		// animations. skipFactor handles the speed difference.
+		m.banner.advance()
 		tickCmd := tea.Tick(m.tickRate, func(t time.Time) tea.Msg {
 			return tickMsg(t)
 		})
@@ -192,6 +206,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.FlagsRowPosition = msg.FlagsRowPosition
 		if m.FlagsRowPosition != FlagsRowPositionTop && m.FlagsRowPosition != FlagsRowPositionBottom {
 			m.FlagsRowPosition = FlagsRowPositionBottom
+		}
+
+		// Initialise the banner state from the OvertureMsg. The
+		// bannerState is nil when the banner is disabled, when the
+		// gradient binding is absent, or when the state pointer is
+		// nil. The view checks for nil before rendering.
+		m.bannerInfo = msg.Banner
+		if !msg.Banner.Disable && msg.Banner.State != nil && msg.Banner.Gradient != nil {
+			m.banner = newBannerState(msg.Banner.State, msg.Banner.Tick, m.tickRate)
+		} else {
+			m.banner = nil
 		}
 
 		return m, nil

--- a/src/prism/highway/view.go
+++ b/src/prism/highway/view.go
@@ -3,11 +3,20 @@ package highway
 import (
 	"strings"
 
-	"charm.land/bubbletea/v2"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
 )
 
 func (m Model) View() tea.View {
 	var b strings.Builder
+
+	// Banner at top: rendered OUTSIDE the bordered region, above the
+	// top border. This is independent of the flags row position
+	// because the flags row lives INSIDE the border.
+	if m.banner != nil && m.bannerInfo.Position == BannerPositionTop {
+		m.bannerInfo.renderTo(&b, m.width)
+	}
 
 	m.renderHeader(&b)
 	if m.FlagsRowPosition == FlagsRowPositionTop {
@@ -19,7 +28,43 @@ func (m Model) View() tea.View {
 	}
 	m.renderSummary(&b)
 
+	// Banner at bottom: rendered OUTSIDE the bordered region, below
+	// the summary. The summary's last line is the bottom border
+	// (no trailing newline), so we emit a separator newline to
+	// keep the banner from overwriting the border.
+	if m.banner != nil && m.bannerInfo.Position == BannerPositionBottom {
+		b.WriteByte('\n')
+		m.bannerInfo.renderTo(&b, m.width)
+	}
+
 	v := tea.NewView(b.String())
 	v.AltScreen = true
 	return v
+}
+
+// renderTo invokes the banner widget and writes the result to b.
+// Centralising the call here means the view.go body stays purely
+// about layout, and the banner widget stays decoupled from the
+// highway model.
+func (info BannerInfo) renderTo(b *strings.Builder, width int) {
+	if info.Gradient == nil || info.State == nil {
+		return
+	}
+	out := banner.Render(banner.Config{
+		Width:   width,
+		Justify: info.Justify,
+	}, banner.Styles{}, banner.Effect{
+		Gradient: info.Gradient,
+		State:    info.State,
+		Aspects: banner.Aspects{
+			Orientation: banner.Orientation(info.Aspects.Orientation),
+			Banding:     banner.Banding(info.Aspects.Banding),
+			Unity:       banner.Unity(info.Aspects.Unity),
+			FixedEnd:    banner.FixedEnd(info.Aspects.FixedEnd),
+		},
+	})
+	if out == "" {
+		return
+	}
+	b.WriteString(out)
 }

--- a/src/prism/widgets/banner/aspects.go
+++ b/src/prism/widgets/banner/aspects.go
@@ -1,0 +1,138 @@
+package banner
+
+import "math/rand/v2"
+
+// Orientation selects whether the gradient sweeps across rows or down
+// columns of the banner art.
+type Orientation int
+
+const (
+	// OrientationHorizontal sweeps left-to-right (or right-to-left,
+	// depending on the gradient state's initial direction) across the
+	// banner. The position used to look up the gradient step is the
+	// rune's column index.
+	OrientationHorizontal Orientation = iota
+
+	// OrientationVertical sweeps top-to-bottom (or bottom-to-top)
+	// across the banner. The position used to look up the gradient
+	// step is the rune's row index.
+	OrientationVertical
+)
+
+// Banding controls how the gradient repeats once it reaches the end of
+// the banner.
+type Banding int
+
+const (
+	// BandingWithout renders a single sweep from one end of the
+	// banner to the other. The gradient state's natural reverse-on-end
+	// behaviour still applies (so the sweep bounces back rather than
+	// jumping to the start).
+	BandingWithout Banding = iota
+
+	// BandingWith repeats the gradient using the number of steps in
+	// the gradient definition. The reverse-on-end behaviour avoids
+	// hard contrast jumps at the turnaround.
+	BandingWith
+)
+
+// Unity controls which class of characters receives the gradient sweep.
+type Unity int
+
+const (
+	// UnityUnified applies the gradient to both face and shadow
+	// characters. FixedEnd is ignored.
+	UnityUnified Unity = iota
+
+	// UnityGradientFace applies the gradient to face characters only;
+	// shadow characters are fixed to either the gradient's Hi or Lo
+	// colour depending on FixedEnd.
+	UnityGradientFace
+
+	// UnityShadowFace applies the gradient to shadow characters only;
+	// face characters are fixed to either the gradient's Hi or Lo
+	// colour depending on FixedEnd.
+	UnityShadowFace
+)
+
+// FixedEnd selects which end of the gradient the non-swept character
+// class is locked to. It is only meaningful when Unity is not Unified.
+type FixedEnd int
+
+const (
+	// FixedEndUnfixed indicates that the FixedEnd is irrelevant
+	// (Unity is Unified). It is the value assigned by randomiseAspects
+	// when Unity is Unified.
+	FixedEndUnfixed FixedEnd = iota
+
+	// FixedEndHi locks the non-swept character class to the gradient's
+	// Hi colour.
+	FixedEndHi
+
+	// FixedEndLo locks the non-swept character class to the gradient's
+	// Lo colour.
+	FixedEndLo
+)
+
+// Aspects captures the three orthogonal visual aspects selected at
+// startup. They remain in effect for the entire application lifetime -
+// the random selection happens once, not per-render.
+type Aspects struct {
+	Orientation Orientation
+	Banding     Banding
+	Unity       Unity
+	// FixedEnd is only meaningful when Unity is not Unified; it is
+	// set to FixedEndUnfixed by randomiseAspects when Unity is Unified.
+	FixedEnd FixedEnd
+}
+
+// randomiseAspects picks the four aspect values that govern the banner's
+// animation for the duration of the process. The call is expected to
+// happen exactly once during startup (in the highway presenter) so the
+// chosen aspects remain in effect for the entire application lifetime.
+//
+// Selection logic:
+//   - Orientation - 50/50 horizontal/vertical
+//   - Banding     - 50/50 without/with
+//   - Unity       - uniform pick over the three values
+//   - FixedEnd    - 50/50 hi/lo, but only when Unity is not Unified.
+//     When Unity is Unified, FixedEnd is set to FixedEndUnfixed so
+//     downstream code can detect "irrelevant" by a single equality.
+func randomiseAspects(rng *rand.Rand) Aspects {
+	orientation := OrientationHorizontal
+	if rng.IntN(2) == 1 {
+		orientation = OrientationVertical
+	}
+
+	banding := BandingWithout
+	if rng.IntN(2) == 1 {
+		banding = BandingWith
+	}
+
+	unity := Unity(rng.IntN(3))
+
+	fixedEnd := FixedEndUnfixed
+	if unity != UnityUnified {
+		if rng.IntN(2) == 0 {
+			fixedEnd = FixedEndHi
+		} else {
+			fixedEnd = FixedEndLo
+		}
+	}
+
+	return Aspects{
+		Orientation: orientation,
+		Banding:     banding,
+		Unity:       unity,
+		FixedEnd:    fixedEnd,
+	}
+}
+
+// RandomiseAspects is the public entry point for aspect randomisation.
+// Callers (typically the highway presenter) are expected to call this
+// exactly once at startup with a freshly-seeded *rand.Rand so the
+// chosen aspects remain in effect for the entire application
+// lifetime. The test-only export_test.go wrapper delegates here.
+func RandomiseAspects(rng *rand.Rand) Aspects {
+	return randomiseAspects(rng)
+}

--- a/src/prism/widgets/banner/banner-defs.go
+++ b/src/prism/widgets/banner/banner-defs.go
@@ -1,0 +1,78 @@
+package banner
+
+import "time"
+
+// ---------------------------------------------------------------------------
+// Banner position
+// ---------------------------------------------------------------------------
+//
+// The banner is rendered OUTSIDE the bordered region of the host view.
+// These constants therefore do not interact with the highway view's
+// FlagsRowPosition - the flags row lives inside the border, the banner
+// lives outside it.
+
+const (
+	// PositionTop places the banner above the top border.
+	PositionTop = "top"
+
+	// PositionBottom places the banner below the summary (and thus
+	// below the bottom border).
+	PositionBottom = "bottom"
+)
+
+// ---------------------------------------------------------------------------
+// Justification
+// ---------------------------------------------------------------------------
+
+const (
+	// JustifyRight aligns the right edge of every banner line with
+	// the right edge of the terminal. This is the default.
+	JustifyRight = "right"
+
+	// JustifyLeft preserves the banner's intrinsic leading spaces
+	// without further padding. The art is therefore rendered flush
+	// against the left of the host view.
+	JustifyLeft = "left"
+
+	// JustifyCenter centres every banner line within the terminal.
+	JustifyCenter = "center"
+)
+
+// ---------------------------------------------------------------------------
+// Character classes
+// ---------------------------------------------------------------------------
+
+// faceRune is the FULL BLOCK glyph (U+2588). It is the only character
+// classified as a "face" rune for the purposes of the unity aspect.
+const faceRune = '█'
+
+// ---------------------------------------------------------------------------
+// Animation timing
+// ---------------------------------------------------------------------------
+
+// DefaultBannerTick is the tick interval (milliseconds) used by the
+// banner animation when the user has not configured one. It is
+// deliberately slower than the highway's global tick (~50ms) so the
+// gradient sweep reads as a warm glow rather than a strobe.
+const DefaultBannerTick = 500 * time.Millisecond
+
+// ---------------------------------------------------------------------------
+// Default art
+// ---------------------------------------------------------------------------
+
+// DefaultArt is the JAYWALK ASCII banner used when the caller does not
+// provide their own Art. It contains 6 lines rendered with FULL BLOCK
+// (█) face runes and box-drawing shadow runes (╔╗╚╝═║). The art is
+// designed for a 24-rune-wide right-justified presentation against a
+// typical 80-column terminal. Each line is prefixed with a single space
+// so the inner face characters start in column 1.
+//
+// Callers can override the art by setting Config.Art.
+const DefaultArt = `
+     ██╗ █████╗ ██╗   ██╗██╗    ██╗ █████╗ ██╗     ██╗  ██╗
+     ██║██╔══██╗╚██╗ ██╔╝██║    ██║██╔══██╗██║     ██║ ██╔╝
+     ██║███████║ ╚████╔╝ ██║ █╗ ██║███████║██║     █████╔╝ 
+██   ██║██╔══██║  ╚██╔╝  ██║███╗██║██╔══██║██║     ██╔═██╗ 
+╚█████╔╝██║  ██║   ██║   ╚███╔███╔╝██║  ██║███████╗██║  ██╗
+ ╚════╝ ╚═╝  ╚═╝   ╚═╝    ╚══╝╚══╝ ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝
+`

--- a/src/prism/widgets/banner/banner-suite_test.go
+++ b/src/prism/widgets/banner/banner-suite_test.go
@@ -1,0 +1,13 @@
+package banner_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBanner(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Banner Suite")
+}

--- a/src/prism/widgets/banner/banner.go
+++ b/src/prism/widgets/banner/banner.go
@@ -1,0 +1,326 @@
+package banner
+
+import (
+	"fmt"
+	"image/color"
+	"strings"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+	"github.com/snivilised/jaywalk/src/prism/effects"
+)
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// Config carries the inputs to Render. Art is the multi-line ASCII art
+// to display. Width is the terminal width used by justification.
+// Justify selects the horizontal alignment of the banner within Width.
+type Config struct {
+	Art     string
+	Width   int
+	Justify string
+}
+
+// Styles is reserved for future use; the banner derives its appearance
+// from the gradient colour sweep alone. The widget is theme-driven via
+// the existing palette/components pipeline, so no lipgloss.Style
+// fields are required.
+type Styles struct{}
+
+// Effect bundles the gradient colour endpoints, the per-widget
+// animation state and the frozen aspect selection made at startup.
+type Effect struct {
+	Gradient *contract.ResolvedGradient
+	State    *effects.GradientState
+	Aspects  Aspects
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+// Render produces the ANSI-styled banner string.
+//
+// Behavioural rules:
+//   - Returns "" when Art and DefaultArt are both empty (which is
+//     only possible if the caller has explicitly passed an empty
+//     Art; the default is the JAYWALK banner from banner-defs.go).
+//   - When Gradient or State is nil the art is returned without
+//     ANSI colour codes (graceful fallback, mirroring activity.Render).
+//   - Spaces and newlines are passed through untouched so the art's
+//     own alignment is preserved.
+//   - Face characters (█) and shadow characters (anything else
+//     non-space) are styled per the Aspects selection.
+//   - Leading and trailing newlines on the art are trimmed so the
+//     source can be written in a human-readable form (e.g. with a
+//     newline immediately after the opening backtick of a raw
+//     string literal). The output is always terminated with a
+//     single newline so the banner sits on its own lines.
+func Render(cfg Config, _ Styles, effect Effect) string {
+	art := cfg.Art
+	if art == "" {
+		art = DefaultArt
+	}
+	if art == "" {
+		return ""
+	}
+
+	// Trim leading and trailing newlines so the source can use
+	// idiomatic raw-string formatting (newline after opening
+	// backtick, newline before closing backtick). This leaves the
+	// actual line content (including any leading spaces) intact.
+	art = strings.Trim(art, "\n")
+	if art == "" {
+		return ""
+	}
+
+	if effect.Gradient == nil || effect.State == nil {
+		return art + "\n"
+	}
+
+	steps := paletteSteps(effect.Gradient, effect.State)
+	if len(steps) == 0 {
+		return art + "\n"
+	}
+
+	lines := strings.Split(art, "\n")
+	pads := applyJustification(lines, cfg.Width, cfg.Justify)
+
+	// posOfLine[i] is the global rune position of the first rune of
+	// the i-th line in the un-justified art. Used for Horizontal
+	// orientation.
+	posOfLine := buildPosOfLine(lines)
+
+	// rowOfGlobalPos[pos] is the row index of the rune at global
+	// position pos. Used for Vertical orientation.
+	rowOfGlobalPos := buildRowOfGlobalPos(lines)
+
+	var b strings.Builder
+	for i, line := range lines {
+		b.WriteString(pads[i])
+		writeColouredLine(&b, line, posOfLine[i], rowOfGlobalPos, effect, steps)
+		if i < len(lines)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	// Trailing newline so the banner sits on its own lines and
+	// does not concatenate with whatever the host view renders
+	// above (top banner) or below (bottom banner).
+	b.WriteByte('\n')
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Position maps
+// ---------------------------------------------------------------------------
+
+// buildPosOfLine returns, for each line, the global rune index of its
+// first rune. The cumulative offset between lines includes the newline
+// rune so the gradient sweep is continuous across line breaks.
+func buildPosOfLine(lines []string) []int {
+	pos := make([]int, len(lines))
+	cursor := 0
+	for i, line := range lines {
+		pos[i] = cursor
+		cursor += len([]rune(line)) + 1 // +1 for '\n'
+	}
+	return pos
+}
+
+// buildRowOfGlobalPos returns a slice mapping the global rune index in
+// the un-justified art to the row (line number) it belongs to. The
+// slice has one entry per rune.
+func buildRowOfGlobalPos(lines []string) []int {
+	total := 0
+	for _, l := range lines {
+		total += len([]rune(l))
+	}
+	rows := make([]int, total)
+	cursor := 0
+	for lineIdx, line := range lines {
+		n := len([]rune(line))
+		for j := 0; j < n; j++ {
+			rows[cursor+j] = lineIdx
+		}
+		cursor += n
+	}
+	return rows
+}
+
+// ---------------------------------------------------------------------------
+// Per-rune colour resolution
+// ---------------------------------------------------------------------------
+
+// colourPolicy describes how a non-whitespace rune is coloured.
+type colourPolicy struct {
+	fixed bool // true => use a fixed endpoint, ignore gradient sweep
+	hi    bool // when fixed: true => Hi, false => Lo
+}
+
+// policyFor returns the colour policy for a non-whitespace rune given
+// the active aspects.
+func policyFor(isFace bool, a Aspects) colourPolicy {
+	switch a.Unity {
+	case UnityUnified:
+		return colourPolicy{}
+	case UnityGradientFace:
+		if isFace {
+			return colourPolicy{} // face sweeps
+		}
+		return colourPolicy{fixed: true, hi: a.FixedEnd != FixedEndLo}
+	case UnityShadowFace:
+		if !isFace {
+			return colourPolicy{} // shadow sweeps
+		}
+		return colourPolicy{fixed: true, hi: a.FixedEnd != FixedEndLo}
+	}
+	return colourPolicy{}
+}
+
+// runeColour returns the RGB colour for the rune at global position
+// pos in the art, based on its face/shadow class and the active unity
+// aspect.
+func runeColour(pos int, r rune, effect Effect, steps []contract.Colour, rows []int) contract.Colour {
+	isFace := r == faceRune
+	p := policyFor(isFace, effect.Aspects)
+	if p.fixed {
+		c := effect.Gradient.Lo
+		if p.hi {
+			c = effect.Gradient.Hi
+		}
+		return rgbOf(c)
+	}
+	// Gradient path: index into the step palette via the state, using
+	// the orientation aspect to decide whether to index by column or
+	// row.
+	var stepIdx int
+	switch effect.Aspects.Orientation {
+	case OrientationVertical:
+		row := 0
+		if pos >= 0 && pos < len(rows) {
+			row = rows[pos]
+		}
+		stepIdx = effect.State.GetEffectiveIndex(row)
+	case OrientationHorizontal:
+		stepIdx = effect.State.GetEffectiveIndex(pos)
+	}
+	if stepIdx < 0 || stepIdx >= len(steps) {
+		stepIdx = 0
+	}
+	return steps[stepIdx]
+}
+
+// ---------------------------------------------------------------------------
+// Line rendering
+// ---------------------------------------------------------------------------
+
+// writeColouredLine emits the ANSI-styled version of one line. lineStart
+// is the global rune index of the first character of the line in the
+// un-justified art, used by Horizontal orientation.
+func writeColouredLine(b *strings.Builder, line string, lineStart int, rows []int, effect Effect, steps []contract.Colour) {
+	runes := []rune(line)
+	for localIdx, r := range runes {
+		if r == ' ' || r == '\n' || r == '\t' {
+			b.WriteRune(r)
+			continue
+		}
+		pos := lineStart + localIdx
+		col := runeColour(pos, r, effect, steps, rows)
+		emitAnsiRune(b, r, col)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Justification
+// ---------------------------------------------------------------------------
+
+// applyJustification returns the per-line leading-space padding
+// required to align each line under the configured Justify mode. The
+// banner's intrinsic leading spaces are preserved; the padding is
+// appended in front of them.
+//
+//	right: pad = max(0, Width - lineWidth)
+//	left:   pad = 0
+//	center: pad = max(0, (Width - lineWidth) / 2)
+func applyJustification(lines []string, width int, justify string) []string {
+	out := make([]string, len(lines))
+	for i, line := range lines {
+		lineWidth := len([]rune(line))
+		var pad int
+		switch justify {
+		case JustifyLeft:
+			pad = 0
+		case JustifyCenter:
+			if width > lineWidth {
+				pad = (width - lineWidth) / 2
+			}
+		default: // JustifyRight (and unknown)
+			if width > lineWidth {
+				pad = width - lineWidth
+			}
+		}
+		if pad > 0 {
+			out[i] = strings.Repeat(" ", pad)
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Gradient step palette
+// ---------------------------------------------------------------------------
+
+// paletteSteps returns the interpolated step array for the given
+// gradient, lazily populating the state's steps array the first time it
+// is called. This mirrors the lazy population in effects.ApplyGradient
+// (see gradient-state.go:108-112).
+func paletteSteps(g *contract.ResolvedGradient, st *effects.GradientState) []contract.Colour {
+	if g == nil || st == nil {
+		return nil
+	}
+	if st.TotalSteps <= 0 {
+		st.TotalSteps = g.Steps
+	}
+	if st.TotalSteps <= 0 {
+		st.TotalSteps = contract.DefaultStepCount()
+	}
+	hiR, hiG, hiB, _ := g.Hi.RGBA()
+	loR, loG, loB, _ := g.Lo.RGBA()
+	steps := effects.InterpolateBetweenRGBA(
+		uint8(hiR>>8), uint8(hiG>>8), uint8(hiB>>8), //nolint:gosec // safe: 16-bit value >> 8 fits in 8 bits
+		uint8(loR>>8), uint8(loG>>8), uint8(loB>>8), //nolint:gosec // safe: 16-bit value >> 8 fits in 8 bits
+		st.TotalSteps,
+	)
+	if len(steps) > 0 {
+		st.SetSteps(steps)
+	}
+	return steps
+}
+
+// rgbOf converts a color.Color to an 8-bit-per-channel contract.Colour.
+func rgbOf(c color.Color) contract.Colour {
+	if c == nil {
+		return contract.Colour{}
+	}
+	r, g, b, _ := c.RGBA()
+	return contract.Colour{
+		R: uint8(r >> 8), //nolint:gosec
+		G: uint8(g >> 8), //nolint:gosec
+		B: uint8(b >> 8), //nolint:gosec
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ANSI emission
+// ---------------------------------------------------------------------------
+
+// emitAnsiRune writes a single coloured rune to b using 24-bit ANSI
+// escape codes. The escape sequence mirrors the one used by
+// effects.ApplyGradientStyled (see gradient-state.go:212) so the
+// output is compatible with every other widget.
+func emitAnsiRune(b *strings.Builder, r rune, col contract.Colour) {
+	_, _ = fmt.Fprintf(b, "\x1b[38;2;%d;%d;%dm", col.R, col.G, col.B)
+	b.WriteRune(r)
+	b.WriteString("\x1b[0m")
+}

--- a/src/prism/widgets/banner/banner_test.go
+++ b/src/prism/widgets/banner/banner_test.go
@@ -1,0 +1,566 @@
+//go:build !race
+// +build !race
+
+package banner_test
+
+import (
+	"fmt"
+	"image/color"
+	"math/rand/v2"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+	"github.com/snivilised/jaywalk/src/prism/effects"
+	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
+)
+
+// smallArt is a 3-line mini banner used for unit tests. It contains
+// face characters (█), shadow characters (╗, ║, ═) and spaces, so all
+// three classes are exercised. The art's intrinsic width (max line
+// rune count) is 18.
+const smallArt = "██╗     ██╗\n" +
+	"║ ║     ║ ║\n" +
+	"╚═╝     ╚═╝"
+
+var _ = Describe("Banner.Render", func() {
+	Describe("visibility / disabled", func() {
+		It("falls back to DefaultArt when Art is empty", func() {
+			out := banner.Render(
+				banner.Config{Art: ""},
+				banner.Styles{},
+				banner.Effect{},
+			)
+			// Empty Art + empty gradient = plain default art,
+			// which contains face runes and no ANSI codes.
+			Expect(out).NotTo(BeEmpty())
+			Expect(out).To(ContainSubstring("█"))
+			Expect(out).NotTo(ContainSubstring("\x1b["))
+		})
+
+		It("returns plain art when Gradient is nil", func() {
+			out := banner.Render(
+				banner.Config{Art: smallArt},
+				banner.Styles{},
+				banner.Effect{Gradient: nil, State: newState()},
+			)
+			// Render always appends a trailing newline so the
+			// banner sits on its own lines.
+			Expect(out).To(Equal(smallArt + "\n"))
+			Expect(out).NotTo(ContainSubstring("\x1b["))
+		})
+
+		It("returns plain art when State is nil", func() {
+			grad := newGradient()
+			out := banner.Render(
+				banner.Config{Art: smallArt},
+				banner.Styles{},
+				banner.Effect{Gradient: grad, State: nil},
+			)
+			// Render always appends a trailing newline so the
+			// banner sits on its own lines.
+			Expect(out).To(Equal(smallArt + "\n"))
+			Expect(out).NotTo(ContainSubstring("\x1b["))
+		})
+
+		It("tolerates a leading carriage return in the art", func() {
+			// Simulates the human-readable raw-string format used
+			// for DefaultArt (newline after the opening backtick).
+			withCR := "\n" + smallArt
+			out := banner.Render(
+				banner.Config{Art: withCR},
+				banner.Styles{},
+				banner.Effect{Gradient: nil, State: newState()},
+			)
+			// The leading CR must be stripped so the banner does
+			// not start with an empty padded line. Render's
+			// trailing newline then takes its place.
+			Expect(out).To(Equal(smallArt + "\n"))
+		})
+
+		It("tolerates a trailing carriage return in the art", func() {
+			withCR := smallArt + "\n"
+			out := banner.Render(
+				banner.Config{Art: withCR},
+				banner.Styles{},
+				banner.Effect{Gradient: nil, State: newState()},
+			)
+			// Only ONE trailing newline should remain (the one
+			// Render adds to separate the banner from the host
+			// view), not the original one plus Render's.
+			Expect(out).To(Equal(smallArt + "\n"))
+		})
+	})
+
+	Describe("unified gradient", func() {
+		var (
+			grad   *contract.ResolvedGradient
+			state  *effects.GradientState
+			effect banner.Effect
+		)
+
+		BeforeEach(func() {
+			grad = newGradient()
+			state = newState()
+			effect = banner.Effect{
+				Gradient: grad,
+				State:    state,
+				Aspects:  banner.Aspects{Unity: banner.UnityUnified},
+			}
+		})
+
+		It("colours both face and shadow characters", func() {
+			out := banner.Render(banner.Config{Art: smallArt}, banner.Styles{}, effect)
+			Expect(out).NotTo(BeEmpty())
+			Expect(out).To(ContainSubstring("\x1b[38;2;"))
+		})
+
+		It("includes the gradient's Hi and Lo colours in the output", func() {
+			// Use a 4-rune non-whitespace line so that all four
+			// steps of the gradient are reachable from the start.
+			lineArt := "████"
+			// First render populates the state's steps array.
+			_ = banner.Render(banner.Config{Art: lineArt}, banner.Styles{}, effect)
+			// At state.Offset=0, the four positions all map to the
+			// same step (step[0] = Hi) because the gradient is
+			// 4 steps long and there are 4 positions. To reach
+			// Lo, advance the state by 3.
+			state.Update(3)
+			out := banner.Render(banner.Config{Art: lineArt}, banner.Styles{}, effect)
+			// Hi = (255, 0, 0), Lo = (0, 0, 255)
+			Expect(out).To(ContainSubstring("\x1b[38;2;0;0;255m"))
+		})
+
+		It("preserves spaces and newlines (alignment not disturbed)", func() {
+			out := banner.Render(banner.Config{Art: smallArt}, banner.Styles{}, effect)
+			// Strip ANSI codes; Render appends a trailing newline
+			// so the banner sits on its own lines, hence the +"\n".
+			Expect(stripAnsi(out)).To(Equal(smallArt + "\n"))
+		})
+	})
+
+	Describe("unity = GradientFace", func() {
+		var grad *contract.ResolvedGradient
+		var state *effects.GradientState
+
+		BeforeEach(func() {
+			grad = newGradient()
+			state = newState()
+		})
+
+		It("locks shadow characters to a single colour (FixedEnd = Hi)", func() {
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{
+					Unity:    banner.UnityGradientFace,
+					FixedEnd: banner.FixedEndHi,
+				},
+			}
+			out := banner.Render(banner.Config{Art: smallArt}, banner.Styles{}, effect)
+
+			// The ping-pong gradient can place face runes at the
+			// Lo step (e.g. when the phase maps to 2*(n-1) - phase
+			// = n-1). The strict invariant however is that NO
+			// shadow rune uses Lo - they are all pinned to Hi.
+			// We verify this by ensuring the number of Hi codes
+			// is at least the number of shadow runes (face runes
+			// may also be Hi and add to the count, but cannot
+			// subtract from it).
+			hiCount := strings.Count(out, "\x1b[38;2;255;0;0m")
+			shadowRunes := countShadows(smallArt)
+			faceRunes := countFaces(smallArt)
+			Expect(hiCount).To(BeNumerically(">=", shadowRunes),
+				"every shadow rune must use the Hi colour")
+
+			// Lo codes are allowed (face runes can hit Lo via
+			// the ping-pong), but there must be no MORE Lo codes
+			// than there are face runes.
+			loCount := strings.Count(out, "\x1b[38;2;0;0;255m")
+			Expect(loCount).To(BeNumerically("<=", faceRunes),
+				"only face runes may be coloured Lo when FixedEnd=Hi")
+		})
+
+		It("locks shadow characters to Lo when FixedEnd = Lo", func() {
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{
+					Unity:    banner.UnityGradientFace,
+					FixedEnd: banner.FixedEndLo,
+				},
+			}
+			out := banner.Render(banner.Config{Art: smallArt}, banner.Styles{}, effect)
+
+			// Every shadow rune is pinned to Lo, so the count of
+			// Lo codes is at least the number of shadow runes.
+			loCount := strings.Count(out, "\x1b[38;2;0;0;255m")
+			shadowRunes := countShadows(smallArt)
+			Expect(loCount).To(BeNumerically(">=", shadowRunes),
+				"every shadow rune must use the Lo colour")
+		})
+	})
+
+	Describe("unity = ShadowFace", func() {
+		var grad *contract.ResolvedGradient
+		var state *effects.GradientState
+
+		BeforeEach(func() {
+			grad = newGradient()
+			state = newState()
+		})
+
+		It("locks face characters to a single colour", func() {
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{
+					Unity:    banner.UnityShadowFace,
+					FixedEnd: banner.FixedEndHi,
+				},
+			}
+			out := banner.Render(banner.Config{Art: smallArt}, banner.Styles{}, effect)
+			// All face runes are pinned to Hi. Count the Hi codes;
+			// it must be at least the number of face runes
+			// (shadow runes may add more if any happen to land on
+			// step 0).
+			hiCount := strings.Count(out, "\x1b[38;2;255;0;0m")
+			faceRunes := countFaces(smallArt)
+			Expect(hiCount).To(BeNumerically(">=", faceRunes))
+		})
+	})
+
+	Describe("orientation", func() {
+		var grad *contract.ResolvedGradient
+		var state *effects.GradientState
+
+		BeforeEach(func() {
+			grad = newGradient()
+			state = newState()
+		})
+
+		It("horizontal: colour index varies with column", func() {
+			// Use a single-line art to make the assertion direct.
+			lineArt := "████╗╗╗╗"
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{
+					Orientation: banner.OrientationHorizontal,
+					Unity:       banner.UnityUnified,
+				},
+			}
+			out := banner.Render(banner.Config{Art: lineArt}, banner.Styles{}, effect)
+			colours := orderedRuneColours(out, lineArt)
+			Expect(colours).To(HaveLen(len([]rune(lineArt))))
+			// Different positions should produce different colours
+			// (or at least the first and last should differ).
+			Expect(colours[0]).NotTo(Equal(colours[len(colours)-1]))
+		})
+
+		It("vertical: same column in different rows gets the same colour", func() {
+			// At state.Offset=0, GetEffectiveIndex(0)=0 → step[0] = Hi
+			// for any position. So all runes look Hi. To verify
+			// vertical orientation we need to set the state offset
+			// and check that the index used is the row, not the
+			// column. We do this by checking that runes in the same
+			// column at different rows get the same colour.
+			columnArt := "█\n█\n█"
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{
+					Orientation: banner.OrientationVertical,
+					Unity:       banner.UnityUnified,
+				},
+			}
+			out := banner.Render(banner.Config{Art: columnArt}, banner.Styles{}, effect)
+			colours := orderedRuneColours(out, columnArt)
+			Expect(colours).To(HaveLen(3))
+			// All three runes are in column 0 of rows 0, 1, 2.
+			// With vertical orientation, all three map to the same
+			// step index (row number, modulo the step count).
+			// At state.Offset=0: stepIdx = (0+row) % 4 → rows 0, 1, 2
+			// map to steps 0, 1, 2 which are all distinct. So the
+			// colours SHOULD differ. Verify they do.
+			Expect(colours[0]).NotTo(Equal(colours[1]))
+			Expect(colours[1]).NotTo(Equal(colours[2]))
+		})
+	})
+
+	Describe("justification", func() {
+		var (
+			grad  *contract.ResolvedGradient
+			state *effects.GradientState
+		)
+
+		BeforeEach(func() {
+			grad = newGradient()
+			state = newState()
+		})
+
+		It("JustifyRight (default) pads so the right edge aligns with Width", func() {
+			// Use Width smaller than the art to ensure no padding
+			// is added; this case is degenerate. Then use a Width
+			// larger than the art to verify padding is added.
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{Unity: banner.UnityUnified},
+			}
+			width := 24
+			out := banner.Render(banner.Config{
+				Art:   smallArt,
+				Width: width,
+				// Justify omitted → default
+			}, banner.Styles{}, effect)
+
+			// Each line of the art has rune count 11; right-justified
+			// at width 24 → pad 13 leading spaces. Render appends a
+			// trailing newline, so Split produces one extra empty
+			// line which we tolerate.
+			lines := strings.Split(out, "\n")
+			Expect(lines).To(HaveLen(4))
+			Expect(lines[3]).To(BeEmpty())
+			for _, line := range lines[:3] {
+				// Count leading spaces (ANSI reset codes do not
+				// count as width because they are zero-width).
+				leading := leadingSpaces(line)
+				Expect(leading).To(Equal(13))
+			}
+		})
+
+		It("JustifyLeft adds no padding", func() {
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{Unity: banner.UnityUnified},
+			}
+			out := banner.Render(banner.Config{
+				Art:     smallArt,
+				Width:   30,
+				Justify: banner.JustifyLeft,
+			}, banner.Styles{}, effect)
+
+			// Art's first line is "██╗     ██╗" - 5 leading spaces
+			// followed by █. The first non-space rune must be at
+			// column 0 of the visible content (i.e. line must not
+			// start with extra spaces).
+			lines := strings.Split(out, "\n")
+			Expect(leadingSpaces(lines[0])).To(Equal(0))
+		})
+
+		It("JustifyCenter pads to the centre of Width", func() {
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{Unity: banner.UnityUnified},
+			}
+			width := 25
+			// lineWidth = 11, pad = (25 - 11) / 2 = 7
+			out := banner.Render(banner.Config{
+				Art:     smallArt,
+				Width:   width,
+				Justify: banner.JustifyCenter,
+			}, banner.Styles{}, effect)
+			lines := strings.Split(out, "\n")
+			// Render appends a trailing newline, so Split produces
+			// one extra empty line which we tolerate by skipping it.
+			for _, line := range lines[:len(lines)-1] {
+				Expect(leadingSpaces(line)).To(Equal(7))
+			}
+		})
+	})
+
+	Describe("newlines pass-through", func() {
+		It("preserves the number of newlines in the art", func() {
+			grad := newGradient()
+			state := newState()
+			effect := banner.Effect{
+				Gradient: grad, State: state,
+				Aspects: banner.Aspects{Unity: banner.UnityUnified},
+			}
+			out := banner.Render(banner.Config{Art: smallArt}, banner.Styles{}, effect)
+			// smallArt has 2 newlines; Render appends a trailing
+			// newline so the banner sits on its own line, hence +1.
+			Expect(strings.Count(out, "\n")).To(Equal(strings.Count(smallArt, "\n") + 1))
+		})
+	})
+})
+
+var _ = Describe("Aspects randomisation", func() {
+	It("covers all three Unity values across many seeds", func() {
+		seen := map[banner.Unity]bool{}
+		for i := 0; i < 200; i++ {
+			rng := rand.New(rand.NewPCG(uint64(i+1), uint64(i+2))) //nolint:gosec // test-only random
+			aspects := banner.RandomiseAspectsForTest(rng)
+			seen[aspects.Unity] = true
+		}
+		Expect(seen).To(HaveLen(3))
+	})
+
+	It("covers both orientations", func() {
+		seen := map[banner.Orientation]bool{}
+		for i := 0; i < 200; i++ {
+			rng := rand.New(rand.NewPCG(uint64(i+1), uint64(i+2))) //nolint:gosec // test-only random
+			aspects := banner.RandomiseAspectsForTest(rng)
+			seen[aspects.Orientation] = true
+		}
+		Expect(seen).To(HaveLen(2))
+	})
+
+	It("covers both banding values", func() {
+		seen := map[banner.Banding]bool{}
+		for i := 0; i < 200; i++ {
+			rng := rand.New(rand.NewPCG(uint64(i+1), uint64(i+2))) //nolint:gosec // test-only random
+			aspects := banner.RandomiseAspectsForTest(rng)
+			seen[aspects.Banding] = true
+		}
+		Expect(seen).To(HaveLen(2))
+	})
+
+	It("sets FixedEnd to Unfixed when Unity is Unified", func() {
+		for i := 0; i < 200; i++ {
+			rng := rand.New(rand.NewPCG(uint64(i+1), uint64(i+2))) //nolint:gosec // test-only random
+			aspects := banner.RandomiseAspectsForTest(rng)
+			if aspects.Unity == banner.UnityUnified {
+				Expect(aspects.FixedEnd).To(Equal(banner.FixedEndUnfixed))
+			}
+		}
+	})
+
+	It("is deterministic for a given seed", func() {
+		rngA := rand.New(rand.NewPCG(42, 99)) //nolint:gosec // test-only random
+		rngB := rand.New(rand.NewPCG(42, 99)) //nolint:gosec // test-only random
+		a := banner.RandomiseAspectsForTest(rngA)
+		b := banner.RandomiseAspectsForTest(rngB)
+		Expect(a).To(Equal(b))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// newGradient returns a fixed Hi=red, Lo=blue, Steps=4 gradient for
+// deterministic test output.
+func newGradient() *contract.ResolvedGradient {
+	return &contract.ResolvedGradient{
+		Steps: 4,
+		Hi:    color.RGBA{R: 255, G: 0, B: 0, A: 255},
+		Lo:    color.RGBA{R: 0, G: 0, B: 255, A: 255},
+	}
+}
+
+func newState() *effects.GradientState {
+	st := effects.NewGradientState()
+	st.TotalSteps = 4
+	return st
+}
+
+// stripAnsi removes ANSI 24-bit colour escape sequences and reset codes
+// from s. Mirrors the lab.StripANSI helper used elsewhere in the
+// codebase.
+var ansiRe = []string{
+	"\x1b[38;2;0;0;0m",
+	"\x1b[38;2;255;255;255m",
+	"\x1b[38;2;255;0;0m",
+	"\x1b[38;2;0;0;255m",
+	"\x1b[0m",
+}
+
+func stripAnsi(s string) string {
+	out := s
+	for _, c := range ansiRe {
+		out = strings.ReplaceAll(out, c, "")
+	}
+	// Generic fallback: strip any remaining \x1b[...m sequences.
+	for {
+		start := strings.Index(out, "\x1b[")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(out[start:], "m")
+		if end < 0 {
+			break
+		}
+		out = out[:start] + out[start+end+1:]
+	}
+	return out
+}
+
+// countShadows returns the number of non-space, non-newline, non-face
+// runes in s.
+func countShadows(s string) int {
+	n := 0
+	for _, r := range s {
+		if r == ' ' || r == '\n' || r == '\t' {
+			continue
+		}
+		if r == '█' {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// countFaces returns the number of face runes (█) in s.
+func countFaces(s string) int {
+	n := 0
+	for _, r := range s {
+		if r == '█' {
+			n++
+		}
+	}
+	return n
+}
+
+// orderedRuneColours returns the RGB colour of each non-whitespace rune
+// in art, in order, extracted from the rendered output. The returned
+// slice is parallel to art's non-whitespace runes.
+func orderedRuneColours(rendered, _ string) []color.RGBA {
+	return findAnsiColours(rendered)
+}
+
+// findAnsiColours extracts the RGB colours from \x1b[38;2;R;G;Bm
+// sequences in s, in order.
+func findAnsiColours(s string) []color.RGBA {
+	var out []color.RGBA
+	prefix := "\x1b[38;2;"
+	for {
+		i := strings.Index(s, prefix)
+		if i < 0 {
+			break
+		}
+		rest := s[i+len(prefix):]
+		end := strings.Index(rest, "m")
+		if end < 0 {
+			break
+		}
+		var r, g, b uint8
+		_, _ = fmt.Sscanf(rest[:end], "%d;%d;%d", &r, &g, &b)
+		out = append(out, color.RGBA{R: r, G: g, B: b, A: 255})
+		s = rest[end+1:]
+	}
+	return out
+}
+
+// leadingSpaces returns the number of leading space characters in s
+// (ignoring ANSI escape sequences).
+func leadingSpaces(s string) int {
+	n := 0
+	inAnsi := false
+	for _, r := range s {
+		if r == 0x1b {
+			inAnsi = true
+			continue
+		}
+		if inAnsi {
+			if r == 'm' {
+				inAnsi = false
+			}
+			continue
+		}
+		if r == ' ' {
+			n++
+			continue
+		}
+		break
+	}
+	return n
+}

--- a/src/prism/widgets/banner/export_test.go
+++ b/src/prism/widgets/banner/export_test.go
@@ -1,0 +1,11 @@
+package banner
+
+import "math/rand/v2"
+
+// RandomiseAspectsForTest is a thin alias for RandomiseAspects that
+// exists for symmetry with other test exports in the codebase. Both
+// names are interchangeable; the production code path uses
+// RandomiseAspects directly.
+func RandomiseAspectsForTest(rng *rand.Rand) Aspects {
+	return RandomiseAspects(rng)
+}

--- a/test/data/rounded-tree.theme.yml
+++ b/test/data/rounded-tree.theme.yml
@@ -175,6 +175,7 @@ palette:
     components:
       activity-control: aurora-borealis
       periscope-control: aurora-borealis
+      banner-control: aurora-borealis
 
 # TreeIcons holds optional glyph configuration used by tree-style
 # stream renderers such as the linear view.

--- a/test/data/square-tree.theme.yml
+++ b/test/data/square-tree.theme.yml
@@ -162,6 +162,7 @@ palette:
     components:
       activity-control: aurora-borealis
       periscope-control: aurora-borealis
+      banner-control: aurora-borealis
 
 # TreeIcons holds optional glyph configuration used by tree-style
 # stream renderers such as the linear view.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable ANSI banner to the highway view with animated gradient effects
  * Banner can be positioned above or below the main content and toggled on/off
  * Customize banner animation speed and gradient step count via configuration
  * Support for text justification (left, center, right) alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->