### PR TITLE
feat(prism): make linear banner consistent with highway view banner (…

### DIFF
--- a/src/app/bedrock/types.go
+++ b/src/app/bedrock/types.go
@@ -162,6 +162,21 @@ type HighwayConfig struct {
 	Banner BannerSubConfig `mapstructure:"banner,omitempty"`
 }
 
+// LinearConfig holds the configuration for the linear view.
+// This configuration is loaded from jay.ui.yml when linear view is requested.
+type LinearConfig struct {
+	// FlagsRowPosition controls the ANSI banner placement:
+	// "top" renders the banner before the linear banner,
+	// "bottom" renders it after the summary banner.
+	// Empty or invalid values default to "bottom".
+	FlagsRowPosition string `mapstructure:"flags-row-position,omitempty"`
+
+	// Banner controls the ANSI shadow banner rendered outside the
+	// linear view's bordered region. The colour sweep is resolved
+	// from the theme via highlights.components["banner-control"].
+	Banner BannerSubConfig `mapstructure:"banner,omitempty"`
+}
+
 // BannerSubConfig holds the raw, on-disk shape of the banner settings
 // loaded from jay.ui.yml. The resolved (palette-aware) shape lives in
 // ui.BannerConfig - see ui/registry.go.

--- a/src/app/ui/linear.go
+++ b/src/app/ui/linear.go
@@ -2,13 +2,17 @@ package ui
 
 import (
 	"fmt"
+	"math/rand/v2"
+	"os"
 	"sync"
+	"time"
 
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/agenor/enums"
 	"github.com/snivilised/jaywalk/src/agenor/pref"
 	"github.com/snivilised/jaywalk/src/app/report"
 	"github.com/snivilised/jaywalk/src/prism/contract"
+	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
 	"github.com/snivilised/jaywalk/src/third/lo"
 )
 
@@ -27,6 +31,8 @@ type linear struct {
 	lastParent   string
 	peerInfo     map[string]*core.PeerInfo
 	renderedDirs map[string]bool
+	cfg          LinearConfig
+	theme        contract.Theme
 }
 
 func (l *linear) OnTraversalOptions(o *pref.Options) {
@@ -49,6 +55,9 @@ func (l *linear) OnBegin(e *report.BeginEvent) {
 	l.lastParent = ""
 	l.renderedDirs = make(map[string]bool)
 
+	// Build banner info for the renderer
+	bannerInfo := l.buildBannerInfo()
+
 	l.renderer.Begin(contract.Overture{
 		Root:       e.Root,
 		Caption:    e.Caption,
@@ -56,6 +65,7 @@ func (l *linear) OnBegin(e *report.BeginEvent) {
 		Kind:       kind,
 		ResumeFrom: e.ResumeFrom,
 		DateFormat: e.DateFormat,
+		Banner:     bannerInfo,
 	})
 }
 
@@ -226,6 +236,46 @@ func (l *linear) ensureParentRendered(node *core.Node) {
 		l.renderedDirs[p.Path] = true
 		l.lastParent = p.Path
 	}
+}
+
+// buildBannerInfo assembles the per-session BannerInfo for the linear
+// renderer. The random aspect selection is performed exactly once here
+// so the aspects are frozen for the duration of the process. The gradient
+// endpoints are resolved from the theme's "banner-control" component,
+// falling back to no gradient when the binding is absent.
+func (l *linear) buildBannerInfo() *contract.BannerInfo {
+	info := &contract.BannerInfo{
+		Disable:  l.cfg.Banner.Disable,
+		Position: l.cfg.FlagsRowPosition,
+		Justify:  l.cfg.Banner.Justify,
+	}
+
+	if l.cfg.Banner.Disable {
+		return info
+	}
+
+	// Resolve the gradient from the theme
+	var grad *contract.ResolvedGradient
+	if g, ok := l.theme.GradientFor(contract.GradientComponentBanner); ok && g.Steps > 0 {
+		steps := g.Steps
+		if l.cfg.Banner.StepsOverride > 0 {
+			steps = l.cfg.Banner.StepsOverride
+		}
+		grad = &contract.ResolvedGradient{Steps: steps, Hi: g.Hi, Lo: g.Lo}
+	}
+	info.Gradient = grad
+
+	// Pick the random aspects ONCE here, not per-render
+	rng := rand.New(rand.NewPCG(uint64(os.Getpid()), uint64(time.Now().UnixNano()))) //nolint:gosec // non-security
+	aspects := banner.RandomiseAspects(rng)
+	info.Aspects = contract.BannerAspects{
+		Orientation: int(aspects.Orientation),
+		Banding:     int(aspects.Banding),
+		Unity:       int(aspects.Unity),
+		FixedEnd:    int(aspects.FixedEnd),
+	}
+
+	return info
 }
 
 // NewLinearWithRenderer constructs a linear presenter backed by the

--- a/src/app/ui/registry.go
+++ b/src/app/ui/registry.go
@@ -117,7 +117,17 @@ type ViewConfig interface {
 // currently has no per-instance settings beyond the palette, so this
 // is a zero-sized placeholder that exists for symmetry with views
 // that do have settings.
-type LinearConfig struct{}
+type LinearConfig struct {
+	// FlagsRowPosition controls the ANSI banner placement:
+	// "top" renders the banner before the linear banner,
+	// "bottom" renders it after the summary banner.
+	FlagsRowPosition string
+
+	// Banner controls the ANSI shadow banner rendered outside the
+	// linear view's bordered region. The colour sweep is resolved
+	// from the theme via highlights.components["banner-control"].
+	Banner BannerConfig
+}
 
 // isViewConfig seals the implementation set.
 func (LinearConfig) isViewConfig() {}
@@ -237,7 +247,7 @@ func LoadConfig(mode string, source ViewConfigSource, palette contract.Palette) 
 
 	switch mode {
 	case ModeLinear:
-		return LinearConfig{}, nil
+		return loadLinearConfig(source, palette)
 
 	case ModeHighway:
 		return loadHighwayConfig(source, palette)
@@ -279,6 +289,44 @@ func loadHighwayConfig(source ViewConfigSource, palette contract.Palette) (ViewC
 		FlagsRowPosition:  flagsRowPosition,
 		Banner:            bannerCfg,
 	}, nil
+}
+
+func loadLinearConfig(source ViewConfigSource, palette contract.Palette) (ViewConfig, error) {
+	var raw bedrock.LinearConfig
+	if source != nil {
+		if err := source.Load("linear", &raw); err != nil {
+			return nil, err
+		}
+	}
+
+	flagsRowPosition := normaliseLinearFlagsRowPosition(raw.FlagsRowPosition)
+	bannerCfg := resolveBannerConfig(raw.Banner, palette)
+
+	return LinearConfig{
+		FlagsRowPosition: flagsRowPosition,
+		Banner:           bannerCfg,
+	}, nil
+}
+
+// normaliseLinearFlagsRowPosition validates the configured flags row position
+// for the linear view. Empty values are treated as unset (use default).
+// Unrecognised values also resolve to the default; a warning is written to
+// stderr so the user is informed but the application is not aborted.
+func normaliseLinearFlagsRowPosition(raw string) string {
+	if raw == "" {
+		return flagsRowPositionDefault
+	}
+
+	switch raw {
+	case FlagsRowPositionTop, FlagsRowPositionBottom:
+		return raw
+	default:
+		fmt.Fprintf(os.Stderr,
+			"warning: ui.linear.flags-row-position: unrecognised value %q, defaulting to %q\n",
+			raw, flagsRowPositionDefault,
+		)
+		return flagsRowPositionDefault
+	}
 }
 
 // normaliseFlagsRowPosition validates the configured flags row position.
@@ -404,7 +452,12 @@ func nameFromPalette(palette contract.Palette, componentName string) string {
 // applies the palette's theme settings (colors, icons, styles). Custom
 // tree icons from the palette are explicitly applied via WithIcons to
 // ensure they override the defaults.
-func newLinearPresenter(palette contract.Palette) (report.Presenter, error) {
+func newLinearPresenter(palette contract.Palette, cfg LinearConfig) (report.Presenter, error) {
+	theme, err := contract.NewTheme(palette, os.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
 	renderer, err := flow.New(
 		palette,
 		os.Stdout,
@@ -414,7 +467,11 @@ func newLinearPresenter(palette contract.Palette) (report.Presenter, error) {
 		return nil, err
 	}
 
-	return &linear{renderer: renderer}, nil
+	return &linear{
+		renderer: renderer,
+		cfg:      cfg,
+		theme:    theme,
+	}, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -438,7 +495,13 @@ func New(mode string, palette contract.Palette, cfg ViewConfig) (report.Presente
 
 	switch mode {
 	case ModeLinear:
-		return newLinearPresenter(palette)
+		lCfg, ok := cfg.(LinearConfig)
+		if !ok {
+			return nil, fmt.Errorf(
+				"ui.New: linear mode requires LinearConfig, got %T", cfg,
+			)
+		}
+		return newLinearPresenter(palette, lCfg)
 
 	case ModeHighway:
 		hCfg, ok := cfg.(HighwayConfig)

--- a/src/prism/contract/overture.go
+++ b/src/prism/contract/overture.go
@@ -29,4 +29,39 @@ type Overture struct {
 	// DateFormat is the Go time format string for rendering StartedAt.
 	// Empty means use the default (time.RFC1123).
 	DateFormat string
+
+	// Banner carries the optional ANSI shadow banner configuration.
+	// Nil when the banner is disabled or not configured.
+	Banner *BannerInfo
+}
+
+// BannerInfo carries the ANSI shadow banner configuration for a renderer.
+// The linear renderer uses this to render a static (non-animated) banner.
+type BannerInfo struct {
+	// Disable hides the banner when true.
+	Disable bool
+
+	// Position selects where the banner is rendered: "top" or "bottom".
+	Position string
+
+	// Justify is the horizontal alignment: "right", "left", or "center".
+	Justify string
+
+	// Width is the terminal width for justification padding.
+	Width int
+
+	// Aspects are the random visual aspects chosen once at startup.
+	Aspects BannerAspects
+
+	// Gradient is the resolved colour endpoints (Hi/Lo) bound to
+	// the "banner-control" theme component.
+	Gradient *ResolvedGradient
+}
+
+// BannerAspects captures the visual aspects for the banner.
+type BannerAspects struct {
+	Orientation int
+	Banding     int
+	Unity       int
+	FixedEnd    int
 }

--- a/src/prism/flow/linear-new.go
+++ b/src/prism/flow/linear-new.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/charmbracelet/x/term"
 	"github.com/snivilised/jaywalk/src/prism/contract"
 )
 
@@ -14,9 +15,15 @@ func New(palette contract.Palette, writer io.Writer, opts ...LinearOption) (cont
 		return nil, fmt.Errorf("flow.New: %w", err)
 	}
 
+	width := 80
+	if w, _, err := term.GetSize(0); err == nil && w > 0 {
+		width = w
+	}
+
 	r := &renderer{
 		theme:     theme,
 		writer:    writer,
+		width:     width,
 		treeIcons: theme.TreeIcons,
 	}
 

--- a/src/prism/flow/linear-renderer.go
+++ b/src/prism/flow/linear-renderer.go
@@ -14,9 +14,13 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/prism/contract"
-	"github.com/snivilised/jaywalk/src/prism/widgets/clock"
+	"github.com/snivilised/jaywalk/src/prism/effects"
+	"github.com/snivilised/jaywalk/src/prism/layout"
+	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
+	"github.com/snivilised/jaywalk/src/prism/widgets/border"
+	"github.com/snivilised/jaywalk/src/prism/widgets/intro"
 	"github.com/snivilised/jaywalk/src/prism/widgets/landing"
-	"github.com/snivilised/jaywalk/src/prism/widgets/summary"
+	"github.com/snivilised/jaywalk/src/prism/widgets/status"
 	"github.com/snivilised/jaywalk/src/third/lo"
 )
 
@@ -25,6 +29,13 @@ import (
 type renderer struct {
 	theme  contract.Theme
 	writer io.Writer
+
+	// width is the terminal width used for full-width banner rendering.
+	width int
+
+	// banner holds the ANSI shadow banner configuration from the Overture.
+	// Nil when the banner is disabled or not configured.
+	banner *contract.BannerInfo
 
 	// treeIcons holds configured tree glyphs from the resolved theme/options.
 	treeIcons contract.TreeIcons
@@ -39,34 +50,94 @@ type renderer struct {
 // Begin renders the opening banner using the Overture metadata. The banner
 // adapts to indicate prime or resume traversal.
 func (r *renderer) Begin(overture contract.Overture) {
-	title := lo.Ternary(overture.Kind == contract.ResumeNavigation,
-		fmt.Sprintf("  jay  resuming %s", overture.Root),
-		fmt.Sprintf("  jay  %s", overture.Root),
-	)
-
 	dateFmt := overture.DateFormat
 	if dateFmt == "" {
 		dateFmt = time.RFC1123
 	}
 
-	caption := fmt.Sprintf("  %s  -  %s",
-		overture.Caption,
-		overture.StartedAt.Format(dateFmt),
-	)
+	// Store banner config for use in Begin (top) and End (bottom)
+	r.banner = overture.Banner
 
+	var b strings.Builder
+
+	// Render ANSI banner at top if position is "top"
+	if r.banner != nil && !r.banner.Disable && r.banner.Position == banner.PositionTop {
+		r.renderAnsiBanner(&b)
+	}
+
+	// Render Top Border with path in brackets (uses contract.Static.Borders)
+	topBorderContent := border.RenderTop(overture.Root, r.width, border.Styles{
+		BorderStyle: r.theme.BorderStyle,
+		PathStyle:   r.theme.RootStyle,
+		CornerStyle: r.theme.BorderStyle,
+	})
+	b.WriteString(topBorderContent)
+
+	// Build caption for intro widget
+	caption := overture.Caption
 	if overture.Kind == contract.ResumeNavigation && overture.ResumeFrom != "" {
 		caption += fmt.Sprintf("  -  from: %s", overture.ResumeFrom)
 	}
 
-	box := r.theme.BoxStyle.
-		MarginTop(0).
-		Render(
-			r.theme.SummaryLabelStyle.Width(0).Render(title) +
-				"\n" +
-				r.theme.SummaryValueStyle.Width(0).Render(caption),
-		)
+	// Render intro line using intro widget
+	introContent := intro.Render(caption, overture.StartedAt, dateFmt, intro.Styles{
+		InfoStyle: r.theme.SummaryValueStyle,
+	})
 
-	_, _ = lipgloss.Fprintln(r.writer, box)
+	// Render header text
+	header := r.theme.HeaderStyle.Render("jay")
+	middle := header + introContent
+
+	// Render row with border caps
+	row := layout.NewRow(r.width-4).
+		Caps(
+			r.theme.BorderStyle.Render("│ "),
+			r.theme.BorderStyle.Render(" │"),
+		).
+		Content(middle)
+	row.RenderTo(&b)
+	b.WriteString("\n")
+
+	// Render bottom border using contract.Static.Borders
+	bottomDashes := strings.Repeat("─", max(0, r.width-7))
+	b.WriteString(r.theme.BorderStyle.Render(
+		contract.Static.Borders.BottomLeft + bottomDashes + contract.Static.Borders.BottomRightCorner,
+	))
+	b.WriteString("\n")
+
+	_, _ = lipgloss.Fprintln(r.writer, b.String())
+}
+
+// renderAnsiBanner renders the static ANSI shadow banner. The gradient is
+// applied based on the randomized aspects but does not animate (Offset stays at 0).
+func (r *renderer) renderAnsiBanner(b *strings.Builder) {
+	if r.banner == nil || r.banner.Gradient == nil {
+		return
+	}
+
+	// Create a static gradient state (Offset=0, never animated)
+	state := effects.NewGradientState()
+	state.TotalSteps = r.banner.Gradient.Steps
+
+	// Convert contract.BannerAspects to banner.Aspects
+	aspects := banner.Aspects{
+		Orientation: banner.Orientation(r.banner.Aspects.Orientation),
+		Banding:     banner.Banding(r.banner.Aspects.Banding),
+		Unity:       banner.Unity(r.banner.Aspects.Unity),
+		FixedEnd:    banner.FixedEnd(r.banner.Aspects.FixedEnd),
+	}
+
+	out := banner.Render(banner.Config{
+		Width:   r.width,
+		Justify: r.banner.Justify,
+	}, banner.Styles{}, banner.Effect{
+		Gradient: r.banner.Gradient,
+		State:    state,
+		Aspects:  aspects,
+	})
+	if out != "" {
+		b.WriteString(out)
+	}
 }
 
 // Show renders a single Motif immediately to the output writer.
@@ -285,60 +356,55 @@ func (r *renderer) updateBranchStack(motif contract.Motif) {
 	r.previousIsLast = motif.IsLast
 }
 
-// End renders the closing summary box with traversal counts and elapsed time.
+// End renders the closing status row with traversal counts and elapsed time.
 func (r *renderer) End(summ contract.Summary) {
-	fileLabel := "Files"
-	dirLabel := "Directories"
-	skippedLabel := "Skipped"
-	elapsedLabel := "Elapsed"
-
-	if summ.Kind == contract.ResumeNavigation {
-		fileLabel = "Files (resumed)"
-		dirLabel = "Dirs (resumed)"
-	}
-
 	errorCount := len(summ.Errors)
 
-	rows := []summary.Field{
-		r.summaryField(contract.TreeIconFile, fileLabel, fmt.Sprintf("%d", summ.FilesVisited)),
-		r.summaryField(contract.TreeIconDirectory, dirLabel, fmt.Sprintf("%d", summ.DirsVisited)),
-		r.summaryField(contract.TreeIconSkipped, skippedLabel, fmt.Sprintf("%d", summ.Skipped)),
-		r.summaryField(contract.TreeIconError, "Errors", fmt.Sprintf("%d", errorCount)),
-		r.summaryField(contract.TreeIconElapsed, elapsedLabel, clock.FormatDuration(summ.Elapsed)),
-	}
-
-	if errorCount > 0 {
-		errorStyles := summary.CellStyles{
-			Icon:  r.theme.ErrorStyle,
-			Label: r.theme.ErrorStyle,
-			Value: r.theme.ErrorStyle,
-		}
-
-		rows[len(rows)-2].Styles = &errorStyles
-
-		for _, err := range summ.Errors {
-			rows = append(rows, summary.Field{
-				Label:  err.Error(),
-				Styles: &errorStyles,
-			})
-		}
-	}
-
-	box := summary.Render(rows, summary.Styles{
-		Box: r.theme.BoxStyle,
-		Default: summary.CellStyles{
-			Icon:  r.theme.SummaryLabelStyle,
-			Label: r.theme.SummaryLabelStyle,
-			Value: r.theme.SummaryValueStyle,
-		},
+	// Render top border (empty content - just corner decorations)
+	topBorder := border.RenderTop("", r.width, border.Styles{
+		BorderStyle: r.theme.BorderStyle,
+		CornerStyle: r.theme.BorderStyle,
 	})
-	_, _ = lipgloss.Fprintln(r.writer, box)
-}
+	_, _ = lipgloss.Fprint(r.writer, topBorder)
 
-func (r *renderer) summaryField(iconKey, label, value string) summary.Field {
-	return summary.Field{
-		Icon:  r.treeIcons[iconKey],
-		Label: label,
-		Value: value,
+	statusStyles := status.Styles{
+		TreeIcons:         r.treeIcons,
+		SummaryLabelStyle: r.theme.SummaryLabelStyle,
+		SummaryValueStyle: r.theme.SummaryValueStyle,
+		ErrorStyle:        r.theme.ErrorStyle,
+		BorderStyle:       r.theme.BorderStyle,
+	}
+
+	fields := status.FieldSelectors{
+		ShowFiles:    true,
+		ShowDirs:     true,
+		ShowErrors:   true,
+		ShowSkipped:  true,
+		ShowProgress: false,
+		ShowComplete: false,
+		ShowElapsed:  true,
+	}
+
+	statusRow := status.Render(status.Config{
+		Files:   int(summ.FilesVisited),
+		Dirs:    int(summ.DirsVisited),
+		Errors:  errorCount,
+		Skipped: int(summ.Skipped),
+		Elapsed: summ.Elapsed,
+	}, statusStyles, fields, r.width)
+
+	_, _ = lipgloss.Fprintln(r.writer, statusRow)
+
+	// Render bottom border
+	bottomBorder := border.RenderBottom(r.width, border.Styles{
+		BorderStyle: r.theme.BorderStyle,
+	})
+	_, _ = lipgloss.Fprintln(r.writer, bottomBorder)
+
+	// Render ANSI banner at bottom if position is "bottom"
+	if r.banner != nil && !r.banner.Disable && r.banner.Position == banner.PositionBottom {
+		var b strings.Builder
+		r.renderAnsiBanner(&b)
+		_, _ = lipgloss.Fprintln(r.writer, b.String())
 	}
 }

--- a/src/prism/flow/linear-renderer_test.go
+++ b/src/prism/flow/linear-renderer_test.go
@@ -2,11 +2,9 @@ package flow_test
 
 import (
 	"bytes"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/x/ansi"
-	"github.com/mattn/go-runewidth"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -104,9 +102,9 @@ var _ = Describe("LinearRenderer", func() {
 		})
 
 		output := w.String()
-		Expect(output).To(ContainSubstring("🔖 Files"))
-		Expect(output).To(ContainSubstring("📁 Directories"))
-		Expect(output).To(ContainSubstring("⏰ Elapsed"))
+		Expect(output).To(ContainSubstring("🔖 files:"))
+		Expect(output).To(ContainSubstring("📁 dirs:"))
+		Expect(output).To(ContainSubstring("⏰ elapsed:"))
 	})
 
 	It("aligns summary values when the elapsed icon has a different display width", func() {
@@ -130,10 +128,10 @@ var _ = Describe("LinearRenderer", func() {
 		})
 
 		output := ansi.Strip(w.String())
-		Expect(output).To(ContainSubstring("🦋 Elapsed"))
-		Expect(summaryValueEndColumn(output, "Files", "55")).To(Equal(summaryValueEndColumn(output, "Directories", "7")))
-		Expect(summaryValueEndColumn(output, "Files", "55")).To(Equal(summaryValueEndColumn(output, "Skipped", "0")))
-		Expect(summaryValueEndColumn(output, "Files", "55")).To(Equal(summaryValueEndColumn(output, "Elapsed", "2ms")))
+		Expect(output).To(ContainSubstring("🦋 elapsed:"))
+		Expect(output).To(ContainSubstring("🔖 files:"))
+		Expect(output).To(ContainSubstring("📁 dirs:"))
+		Expect(output).To(ContainSubstring("⛔️ skipped:"))
 	})
 
 	It("returns a renderer when options are provided", func() {
@@ -148,7 +146,7 @@ var _ = Describe("LinearRenderer", func() {
 		Expect(w.String()).To(ContainSubstring("✻ test/"))
 	})
 
-	It("renders the banner inside the summary border style", func() {
+	It("renders the banner with highway-style borders and widgets", func() {
 		w := &bytes.Buffer{}
 		palette := contract.Palette{}
 
@@ -163,10 +161,17 @@ var _ = Describe("LinearRenderer", func() {
 		})
 
 		output := w.String()
+		// Top border uses contract.Static.Borders
 		Expect(output).To(ContainSubstring(contract.Static.Borders.TopLeftCorner))
-		Expect(output).To(ContainSubstring("jay  ./src/app"))
+		Expect(output).To(ContainSubstring(contract.Static.Borders.TopRight))
+		// Path is rendered inside the top border
+		Expect(output).To(ContainSubstring("[ ./src/app ]"))
+		// Header row shows "jay" and caption with date
+		Expect(output).To(ContainSubstring("jay"))
 		Expect(output).To(ContainSubstring("files and folders  -"))
-		Expect(output).To(ContainSubstring(contract.Static.Borders.BottomLeftCorner))
+		// Bottom border uses contract.Static.Borders
+		Expect(output).To(ContainSubstring(contract.Static.Borders.BottomLeft))
+		Expect(output).To(ContainSubstring(contract.Static.Borders.BottomRightCorner))
 	})
 
 	It("renders final directory children without vertical continuation", func() {
@@ -204,19 +209,3 @@ var _ = Describe("LinearRenderer", func() {
 		Expect(output).To(ContainSubstring("└── 🔖 child\n"))
 	})
 })
-
-func summaryValueEndColumn(output, label, value string) int {
-	for _, line := range strings.Split(output, "\n") {
-		if !strings.Contains(line, label) {
-			continue
-		}
-
-		valueIndex := strings.LastIndex(line, value)
-		Expect(valueIndex).NotTo(Equal(-1), "expected %q to contain summary value %q", line, value)
-
-		return runewidth.StringWidth(line[:valueIndex]) + runewidth.StringWidth(value)
-	}
-
-	Fail("summary label not found: " + label)
-	return 0
-}

--- a/src/prism/highway/model.go
+++ b/src/prism/highway/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/prism/contract"
 	"github.com/snivilised/jaywalk/src/prism/effects"
+	"github.com/snivilised/jaywalk/src/prism/widgets/status"
 )
 
 type tickMsg time.Time
@@ -63,6 +64,11 @@ type Model struct {
 	// bannerInfo is the (immutable for the session) configuration
 	// received via OvertureMsg. The view reads this each render.
 	bannerInfo BannerInfo
+
+	// statusStyles and statusFields are computed once during init and
+	// reused on every render cycle for the summary row.
+	statusStyles status.Styles
+	statusFields status.FieldSelectors
 }
 
 // initLaneSkip computes the per-lane skip factor from each lane's
@@ -105,6 +111,23 @@ func NewModel(lanes []Lane, tickRate time.Duration, rootPath string,
 			progress.WithoutPercentage(),
 			progress.WithWidth(10),
 		),
+		statusStyles: status.Styles{
+			TreeIcons:         theme.TreeIcons,
+			SummaryLabelStyle: theme.SummaryLabelStyle,
+			SummaryValueStyle: theme.SummaryValueStyle,
+			ErrorStyle:        theme.ErrorStyle,
+			ProgressStyle:     theme.ProgressStyle,
+			BorderStyle:       theme.BorderStyle,
+		},
+		statusFields: status.FieldSelectors{
+			ShowFiles:    true,
+			ShowDirs:     true,
+			ShowErrors:   true,
+			ShowSkipped:  false,
+			ShowProgress: true,
+			ShowComplete: true,
+			ShowElapsed:  true,
+		},
 	}
 }
 

--- a/src/prism/highway/render-summary.go
+++ b/src/prism/highway/render-summary.go
@@ -1,18 +1,14 @@
 package highway
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/snivilised/jaywalk/src/prism/contract"
-	"github.com/snivilised/jaywalk/src/prism/layout"
-	"github.com/snivilised/jaywalk/src/prism/widgets/clock"
+	"github.com/snivilised/jaywalk/src/prism/widgets/status"
 )
 
 func (m Model) renderSummary(b *strings.Builder) {
-	borderStyle := m.theme.BorderStyle
-
 	elapsedSecs := 0
 	var elapsed time.Duration
 	if m.done {
@@ -34,66 +30,27 @@ func (m Model) renderSummary(b *strings.Builder) {
 		errors = elapsedSecs / 15
 	}
 
-	pct := m.percent
 	barView := m.progress.ViewAs(float64(m.percent) / 100.0)
 
-	fileIcon := m.theme.TreeIcons[contract.TreeIconFile]
-	fileLabel := m.theme.SummaryLabelStyle.Render(fileIcon + " files:")
-	fileValue := m.theme.SummaryValueStyle.Render(fmt.Sprintf("%4d", files))
-	seg1 := " " + fileLabel + " " + fileValue + " "
+	statusRow := status.Render(status.Config{
+		Files:        files,
+		Dirs:         dirs,
+		Errors:       errors,
+		Elapsed:      elapsed,
+		Percent:      m.percent,
+		IsDone:       m.done,
+		ErrMsg:       m.errMsg,
+		ProgressView: barView,
+	}, m.statusStyles, m.statusFields, m.width)
 
-	dirIcon := m.theme.TreeIcons[contract.TreeIconDirectory]
-	dirLabel := m.theme.SummaryLabelStyle.Render(dirIcon + " dirs:")
-	dirValue := m.theme.SummaryValueStyle.Render(fmt.Sprintf("%3d", dirs))
-	seg2 := " " + dirLabel + " " + dirValue + " "
-
-	errIcon := m.theme.TreeIcons[contract.TreeIconError]
-	errLabel := m.theme.ErrorStyle.Render(errIcon + " errors:")
-	errValue := m.theme.SummaryValueStyle.Render(fmt.Sprintf("%3d", errors))
-	seg3 := " " + errLabel + " " + errValue + " "
-
-	pctLabel := m.theme.ProgressStyle.Render(fmt.Sprintf("%3d%%", pct))
-	seg4 := " " + barView + "  " + pctLabel + " "
-
-	seg5 := ""
-	if m.done {
-		if m.errMsg != "" {
-			label := "❌ Failed: " + m.errMsg
-			if m.errors > 1 {
-				label += fmt.Sprintf(" (+%d more)", m.errors-1)
-			}
-			seg5 = " " + m.theme.ErrorStyle.Render(label) + " "
-		} else {
-			seg5 = " " + m.theme.ProgressStyle.Render("✔ complete") + " "
-		}
-	}
-
-	elapsedIcon := m.theme.TreeIcons[contract.TreeIconElapsed]
-	elapsedLabel := m.theme.SummaryLabelStyle.Render(elapsedIcon + " elapsed:")
-	elapsedStr := clock.FormatDuration(elapsed)
-	elapsedValue := m.theme.SummaryValueStyle.Render(elapsedStr)
-	elapsedText := " " + elapsedLabel + " " + elapsedValue + " "
-
-	row := layout.NewRow(m.width-4).
-		Caps(borderStyle.Render("│ "), borderStyle.Render(" │")).
-		Content(seg1).
-		Content(borderStyle.Render("│")).
-		Content(seg2).
-		Content(borderStyle.Render("│")).
-		Content(seg3).
-		Content(borderStyle.Render("│")).
-		Content(seg4).
-		Content(borderStyle.Render("│")).
-		Content(seg5).
-		RightContent(elapsedText)
-
-	row.RenderTo(b)
+	b.WriteString(statusRow)
 	b.WriteString("\n")
 
 	N := max(0, m.width-7)
-	b.WriteString(borderStyle.Render(
-		"╰─..★." + strings.Repeat("─", N) + "╯",
+	b.WriteString(m.theme.BorderStyle.Render(
+		contract.Static.Borders.BottomLeft + strings.Repeat("─", N) + contract.Static.Borders.BottomRightCorner,
 	))
+
 	if m.done {
 		b.WriteString("\n")
 		b.WriteString(m.theme.MutedStyle.Render(" • press space to exit"))

--- a/src/prism/widgets/border/top-border.go
+++ b/src/prism/widgets/border/top-border.go
@@ -20,24 +20,33 @@ type Styles struct {
 	CornerStyle lipgloss.Style
 }
 
-// RenderTop renders the top border line with corner decorations and root path.
-// The root path is centered between the left and right border segments.
-// If the root path is too long, it is truncated with an ellipsis.
-func RenderTop(rootPath string, width int, styles Styles) string {
-	pathWidth := lipgloss.Width(rootPath)
-	maxPathWidth := width - 13
-	if pathWidth > maxPathWidth {
-		keep := max(0, maxPathWidth-3)
-		rootPath = contract.Ellipses + rootPath[pathWidth-keep:]
-		pathWidth = maxPathWidth
+// RenderTop renders the top border line with corner decorations and optional content.
+// The content is centered between the left and right border segments.
+// If content is empty, the border is rendered without content or brackets.
+// If the content is too long, it is truncated with an ellipsis.
+func RenderTop(content string, width int, styles Styles) string {
+	contentWidth := lipgloss.Width(content)
+	maxContentWidth := width - 13
+
+	if content == "" {
+		N := max(0, width-7)
+		return styles.CornerStyle.Render(
+			contract.Static.Borders.TopLeftCorner + strings.Repeat("─", N) + contract.Static.Borders.TopRight,
+		) + "\n"
 	}
 
-	avail := max(2, width-pathWidth-11)
+	if contentWidth > maxContentWidth {
+		keep := max(0, maxContentWidth-3)
+		content = contract.Ellipses + content[contentWidth-keep:]
+		contentWidth = maxContentWidth
+	}
+
+	avail := max(2, width-contentWidth-11)
 	L := avail / 2
 	R := avail - L
 
 	return styles.CornerStyle.Render(contract.Static.Borders.TopLeftCorner+strings.Repeat("─", L)+"[ ") +
-		styles.PathStyle.Render(rootPath) +
+		styles.PathStyle.Render(content) +
 		styles.CornerStyle.Render(" ]"+strings.Repeat("─", R)+contract.Static.Borders.TopRight) + "\n"
 }
 

--- a/src/prism/widgets/border/top-border_test.go
+++ b/src/prism/widgets/border/top-border_test.go
@@ -75,4 +75,22 @@ var _ = Describe("TopBorder", func() {
 		result := RenderTop(rootPath, width, styles)
 		Expect(result).To(Equal(expect))
 	})
+
+	It("renders border without content when content is empty", func() {
+		theme, _ := contract.NewTheme(contract.SystemPalette(), nil)
+		styles := Styles{
+			BorderStyle: theme.BorderStyle,
+			PathStyle:   theme.RootStyle,
+			CornerStyle: theme.BorderStyle,
+		}
+		width := 40
+
+		N := max(0, width-7)
+		expect := theme.BorderStyle.Render(
+			contract.Static.Borders.TopLeftCorner + strings.Repeat("─", N) + contract.Static.Borders.TopRight,
+		) + "\n"
+
+		result := RenderTop("", width, styles)
+		Expect(result).To(Equal(expect))
+	})
 })

--- a/src/prism/widgets/status/status.go
+++ b/src/prism/widgets/status/status.go
@@ -1,0 +1,214 @@
+package status
+
+import (
+	"fmt"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/snivilised/jaywalk/src/prism/contract"
+	"github.com/snivilised/jaywalk/src/prism/layout"
+)
+
+// Config holds the data for rendering a status row.
+type Config struct {
+	// Files is the number of files visited.
+	Files int
+
+	// Dirs is the number of directories visited.
+	Dirs int
+
+	// Errors is the number of errors encountered.
+	Errors int
+
+	// Skipped is the number of items skipped.
+	Skipped int
+
+	// Elapsed is the time elapsed since traversal started.
+	Elapsed time.Duration
+
+	// Percent is the completion percentage (0-100).
+	// Only shown when Fields.ShowProgress is true.
+	Percent int
+
+	// IsDone indicates whether the traversal is complete.
+	IsDone bool
+
+	// ErrMsg is the error message shown when done with errors.
+	ErrMsg string
+
+	// ProgressView is the pre-rendered progress bar string.
+	// Only shown when Fields.ShowProgress is true.
+	ProgressView string
+}
+
+// Styles holds the lipgloss styles for the status row.
+type Styles struct {
+	// TreeIcons are the glyphs used for field icons.
+	TreeIcons contract.TreeIcons
+
+	// SummaryLabelStyle is applied to field labels.
+	SummaryLabelStyle lipgloss.Style
+
+	// SummaryValueStyle is applied to field values.
+	SummaryValueStyle lipgloss.Style
+
+	// ErrorStyle is applied to error-related content.
+	ErrorStyle lipgloss.Style
+
+	// ProgressStyle is applied to progress-related content.
+	ProgressStyle lipgloss.Style
+
+	// BorderStyle is applied to border characters.
+	BorderStyle lipgloss.Style
+
+	// MutedStyle is applied to secondary text.
+	MutedStyle lipgloss.Style
+}
+
+// FieldSelectors controls which segments are rendered in the status row.
+type FieldSelectors struct {
+	// ShowFiles enables the files count segment.
+	ShowFiles bool
+
+	// ShowDirs enables the directories count segment.
+	ShowDirs bool
+
+	// ShowErrors enables the errors count segment.
+	ShowErrors bool
+
+	// ShowSkipped enables the skipped count segment.
+	ShowSkipped bool
+
+	// ShowProgress enables the progress bar and percentage segment.
+	ShowProgress bool
+
+	// ShowComplete enables the complete/failed message segment.
+	ShowComplete bool
+
+	// ShowElapsed enables the elapsed time segment.
+	ShowElapsed bool
+}
+
+// segment represents a single segment in the status row.
+type segment struct {
+	content   string
+	separator bool // true to render a separator after this segment
+}
+
+// Render produces the status row string with the specified fields.
+func Render(cfg Config, styles Styles, fields FieldSelectors, width int) string {
+	borderStyle := styles.BorderStyle
+
+	segments := make([]segment, 0, 9)
+	var elapsedContent string
+
+	// Files segment
+	if fields.ShowFiles {
+		icon := styles.TreeIcons[contract.TreeIconFile]
+		label := styles.SummaryLabelStyle.Render(icon + " files:")
+		value := styles.SummaryValueStyle.Render(fmt.Sprintf("%4d", cfg.Files))
+		segments = append(segments, segment{
+			content:   " " + label + " " + value + " ",
+			separator: true,
+		})
+	}
+
+	// Dirs segment
+	if fields.ShowDirs {
+		icon := styles.TreeIcons[contract.TreeIconDirectory]
+		label := styles.SummaryLabelStyle.Render(icon + " dirs:")
+		value := styles.SummaryValueStyle.Render(fmt.Sprintf("%3d", cfg.Dirs))
+		segments = append(segments, segment{
+			content:   " " + label + " " + value + " ",
+			separator: true,
+		})
+	}
+
+	// Errors segment
+	if fields.ShowErrors {
+		icon := styles.TreeIcons[contract.TreeIconError]
+		label := styles.ErrorStyle.Render(icon + " errors:")
+		value := styles.SummaryValueStyle.Render(fmt.Sprintf("%3d", cfg.Errors))
+		segments = append(segments, segment{
+			content:   " " + label + " " + value + " ",
+			separator: true,
+		})
+	}
+
+	// Skipped segment
+	if fields.ShowSkipped {
+		icon := styles.TreeIcons[contract.TreeIconSkipped]
+		label := styles.SummaryLabelStyle.Render(icon + " skipped:")
+		value := styles.SummaryValueStyle.Render(fmt.Sprintf("%3d", cfg.Skipped))
+		segments = append(segments, segment{
+			content:   " " + label + " " + value + " ",
+			separator: true,
+		})
+	}
+
+	// Progress segment
+	if fields.ShowProgress && cfg.ProgressView != "" {
+		pctLabel := styles.ProgressStyle.Render(fmt.Sprintf("%3d%%", cfg.Percent))
+		segments = append(segments, segment{
+			content:   " " + cfg.ProgressView + "  " + pctLabel + " ",
+			separator: true,
+		})
+	}
+
+	// Complete/Failed message segment
+	if fields.ShowComplete && cfg.IsDone {
+		var msg string
+		if cfg.ErrMsg != "" {
+			label := "❌ Failed: " + cfg.ErrMsg
+			if cfg.Errors > 1 {
+				label += fmt.Sprintf(" (+%d more)", cfg.Errors-1)
+			}
+			msg = " " + styles.ErrorStyle.Render(label) + " "
+		} else {
+			msg = " " + styles.ProgressStyle.Render("✔ complete") + " "
+		}
+		segments = append(segments, segment{
+			content:   msg,
+			separator: true,
+		})
+	}
+
+	// Elapsed segment (always last, right-aligned)
+	if fields.ShowElapsed {
+		icon := styles.TreeIcons[contract.TreeIconElapsed]
+		label := styles.SummaryLabelStyle.Render(icon + " elapsed:")
+		elapsedStr := formatDuration(cfg.Elapsed)
+		value := styles.SummaryValueStyle.Render(elapsedStr)
+		elapsedContent = " " + label + " " + value + " "
+	}
+
+	// Build the row using layout.NewRow
+	row := layout.NewRow(width-4).
+		Caps(borderStyle.Render("│ "), borderStyle.Render(" │"))
+
+	for _, seg := range segments {
+		row.Content(seg.content)
+		if seg.separator {
+			row.Content(borderStyle.Render("│"))
+		}
+	}
+
+	if elapsedContent != "" {
+		row.RightContent(elapsedContent)
+	}
+
+	return row.Render()
+}
+
+// formatDuration formats a duration as a human-readable string.
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%.0fms", float64(d.Milliseconds()))
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	mins := int(d.Minutes())
+	secs := int(d.Seconds()) % 60
+	return fmt.Sprintf("%dm%02ds", mins, secs)
+}

--- a/src/prism/widgets/status/status_test.go
+++ b/src/prism/widgets/status/status_test.go
@@ -1,0 +1,140 @@
+package status_test
+
+import (
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+	"github.com/snivilised/jaywalk/src/prism/widgets/status"
+)
+
+func TestStatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Status Suite")
+}
+
+var _ = Describe("Status", func() {
+	var (
+		styles status.Styles
+	)
+
+	BeforeEach(func() {
+		styles = status.Styles{
+			TreeIcons: contract.TreeIcons{
+				contract.TreeIconFile:      "🔖",
+				contract.TreeIconDirectory: "📁",
+				contract.TreeIconError:     "🚫",
+				contract.TreeIconSkipped:   "⛔️",
+				contract.TreeIconElapsed:   "⏰",
+			},
+			SummaryLabelStyle: lipgloss.NewStyle(),
+			SummaryValueStyle: lipgloss.NewStyle(),
+			ErrorStyle:        lipgloss.NewStyle(),
+			ProgressStyle:     lipgloss.NewStyle(),
+			BorderStyle:       lipgloss.NewStyle(),
+			MutedStyle:        lipgloss.NewStyle(),
+		}
+	})
+
+	Describe("Render", func() {
+		It("renders all fields when all are enabled", func() {
+			fields := status.FieldSelectors{
+				ShowFiles:    true,
+				ShowDirs:     true,
+				ShowErrors:   true,
+				ShowSkipped:  true,
+				ShowProgress: false,
+				ShowComplete: false,
+				ShowElapsed:  true,
+			}
+
+			output := status.Render(status.Config{
+				Files:   42,
+				Dirs:    7,
+				Errors:  0,
+				Skipped: 3,
+				Elapsed: 5 * time.Second,
+			}, styles, fields, 80)
+
+			Expect(output).To(ContainSubstring("🔖 files:"))
+			Expect(output).To(ContainSubstring("📁 dirs:"))
+			Expect(output).To(ContainSubstring("🚫 errors:"))
+			Expect(output).To(ContainSubstring("⛔️ skipped:"))
+			Expect(output).To(ContainSubstring("⏰ elapsed:"))
+		})
+
+		It("renders only enabled fields", func() {
+			fields := status.FieldSelectors{
+				ShowFiles:    true,
+				ShowDirs:     false,
+				ShowErrors:   false,
+				ShowSkipped:  false,
+				ShowProgress: false,
+				ShowComplete: false,
+				ShowElapsed:  true,
+			}
+
+			output := status.Render(status.Config{
+				Files:   42,
+				Dirs:    7,
+				Errors:  0,
+				Skipped: 3,
+				Elapsed: 5 * time.Second,
+			}, styles, fields, 80)
+
+			Expect(output).To(ContainSubstring("🔖 files:"))
+			Expect(output).To(ContainSubstring("⏰ elapsed:"))
+			Expect(output).ToNot(ContainSubstring("📁 dirs:"))
+			Expect(output).ToNot(ContainSubstring("🚫 errors:"))
+			Expect(output).ToNot(ContainSubstring("⛔️ skipped:"))
+		})
+
+		It("formats duration correctly", func() {
+			fields := status.FieldSelectors{
+				ShowFiles:    false,
+				ShowDirs:     false,
+				ShowErrors:   false,
+				ShowSkipped:  false,
+				ShowProgress: false,
+				ShowComplete: false,
+				ShowElapsed:  true,
+			}
+
+			output := status.Render(status.Config{
+				Elapsed: 90 * time.Second,
+			}, styles, fields, 80)
+
+			Expect(output).To(ContainSubstring("1m30s"))
+		})
+
+		It("formats milliseconds for sub-second durations", func() {
+			fields := status.FieldSelectors{
+				ShowElapsed: true,
+			}
+
+			output := status.Render(status.Config{
+				Elapsed: 500 * time.Millisecond,
+			}, styles, fields, 80)
+
+			Expect(output).To(ContainSubstring("500ms"))
+		})
+
+		It("includes border characters", func() {
+			fields := status.FieldSelectors{
+				ShowFiles:   true,
+				ShowElapsed: true,
+			}
+
+			output := status.Render(status.Config{
+				Files:   42,
+				Elapsed: 5 * time.Second,
+			}, styles, fields, 80)
+
+			Expect(output).To(ContainSubstring("│"))
+		})
+	})
+})


### PR DESCRIPTION
…#593)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linear UI view now supports configurable options for layout and visual elements
  * Added optional decorative banners to the linear view

* **Improvements**
  * Enhanced status summary display with improved formatting and styling
  * Improved border and header rendering in the linear view
  * Refactored rendering logic for better separation of concerns

* **Tests**
  * Updated test coverage to reflect new rendering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->