### PR TITLE
ref(prism): make lanes its own child track widget (#604)

### DIFF
--- a/src/app/ui/highway.go
+++ b/src/app/ui/highway.go
@@ -17,6 +17,7 @@ import (
 	"github.com/snivilised/jaywalk/src/prism/highway"
 	"github.com/snivilised/jaywalk/src/prism/movies"
 	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
+	"github.com/snivilised/jaywalk/src/prism/widgets/track"
 )
 
 // HighwayConfig is declared in registry.go alongside the other view
@@ -269,7 +270,7 @@ func (h *highwayPresenter) OnComplete(t *report.Traversal) {
 	<-h.done
 }
 
-func BuildHighwayLanes(cfg HighwayConfig, now uint) []highway.Lane {
+func BuildHighwayLanes(cfg HighwayConfig, now uint) []track.Lane {
 	// Static worker emoji allocation: shuffle once, assign sequentially per lane.
 	emojis := strings.Fields(cfg.WorkerPool)
 	if len(emojis) == 0 {
@@ -290,7 +291,7 @@ func BuildHighwayLanes(cfg HighwayConfig, now uint) []highway.Lane {
 		numLanes = defaultLaneCount
 	}
 
-	lanes := make([]highway.Lane, numLanes)
+	lanes := make([]track.Lane, numLanes)
 	for i := 0; i < numLanes; i++ {
 		var name string
 		if len(names) > 0 {
@@ -315,7 +316,7 @@ func BuildHighwayLanes(cfg HighwayConfig, now uint) []highway.Lane {
 			interval = 0
 		}
 
-		lanes[i] = highway.Lane{
+		lanes[i] = track.Lane{
 			Emoji:       deck[i%len(deck)],
 			Label:       label,
 			FrameFn:     def.Frames,

--- a/src/prism/highway/messages.go
+++ b/src/prism/highway/messages.go
@@ -82,6 +82,9 @@ type OvertureMsg struct {
 	Banner BannerInfo
 }
 
+// MotifData is the per-node payload sent to the track child widget.
+// The root re-wraps incoming highway.MotifMsg values into
+// track.MotifMsg before forwarding.
 type MotifData struct {
 	Path            string
 	Name            string
@@ -107,10 +110,20 @@ type MotifData struct {
 	PeriscopeGradient *contract.ResolvedGradient
 }
 
+// MotifMsg is the highway-level per-node event message. The root
+// translates it into a track.MotifMsg before forwarding to the
+// track child. Kept in the highway package because external
+// callers (e.g. src/app/ui/highway.go) construct it directly.
 type MotifMsg struct {
 	Data MotifData
 }
 
+// CompleteMsg marks end-of-navigation. Carries the final
+// file/dir counts, error list and elapsed time. The root stores
+// errors/elapsed/errMsg/done in its own state, forwards a
+// track.CompleteMsg{} to the track child (flush signal) and
+// translates the relevant fields into status.CountsMsg,
+// status.ElapsedMsg and status.DoneMsg for the status child.
 type CompleteMsg struct {
 	Files   int
 	Dirs    int
@@ -118,8 +131,10 @@ type CompleteMsg struct {
 	Elapsed time.Duration
 }
 
-// CensusMsg carries the total file/dir counts from a preview traversal.
-// The model uses these to calculate progress percentage during the live pass.
+// CensusMsg carries the total file/dir counts from a preview
+// traversal. The root uses the counts to seed the status widget's
+// progress total; the MaxDepth is forwarded to the track child
+// for the periscope bar fill formula.
 type CensusMsg struct {
 	TotalFiles uint
 	TotalDirs  uint

--- a/src/prism/highway/model.go
+++ b/src/prism/highway/model.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/snivilised/jaywalk/src/agenor/core"
 	"github.com/snivilised/jaywalk/src/prism/contract"
-	"github.com/snivilised/jaywalk/src/prism/effects"
 	"github.com/snivilised/jaywalk/src/prism/widgets/status"
+	"github.com/snivilised/jaywalk/src/prism/widgets/track"
 )
 
 type tickMsg time.Time
@@ -30,41 +30,37 @@ func statusFieldSet() status.FieldSelectors {
 	}
 }
 
+// Model is the bubbletea Model for the highway view. It owns the
+// chrome (header, flags row, summary, banner), the status child
+// widget, and the track child widget. The track child is
+// responsible for lane data, per-tick advance, motif application
+// and per-lane rendering.
 type Model struct {
-	lanes          []Lane
-	skip           []int
-	width          int
-	start          time.Time
-	tickRate       time.Duration
-	totalTicks     int64
-	rootPath       string
-	realMode       bool
-	done           bool
-	noRecurse      bool
-	files          int
-	dirs           int
-	errors         int
-	elapsed        time.Duration
-	currentLaneIdx int
-	totalDirs      uint
-	maxDepth       uint
-	pipelineName   string
-	// TODO(status-widget-state-migration): totalFiles is still
-	// owned by the root in this PR. The CensusMsg path
-	// (highway/model.go Update) forwards it into the status
-	// widget via status.TotalMsg so the widget can compute
-	// percent on its own. The root's local copy remains for
-	// now because the lanes update path still references it
-	// for fake-mode rendering. Move the root copy out once
-	// lanes becomes a proper child model.
+	width        int
+	start        time.Time
+	tickRate     time.Duration
+	totalTicks   int64
+	rootPath     string
+	realMode     bool
+	done         bool
+	errors       int
+	elapsed      time.Duration
+	errMsg       string
+	pipelineName string
+	// totalFiles is still owned by the root in this PR. The
+	// CensusMsg path forwards it into the status widget via
+	// status.TotalMsg so the widget can compute percent on its
+	// own. The root's local copy remains for the demo-mode
+	// fake-percent generator (see tickMsg arm).
 	totalFiles        uint
+	totalDirs         uint
+	maxDepth          uint
+	noRecurse         bool
 	subscriptionLabel string
 	startedAt         time.Time
 	caption           string
 	dateFormat        string
 	theme             contract.Theme
-	counted           map[string]bool
-	errMsg            string
 
 	// status is the child status widget. It owns the
 	// files/dirs/errors/elapsed/isDone/errMsg/percent/total state
@@ -72,6 +68,13 @@ type Model struct {
 	// translates highway messages into status.* messages
 	// (see update.go's translation helpers).
 	status status.Model
+
+	// track is the child widget owning lane data, per-tick
+	// advance, motif application and per-lane rendering. The
+	// root forwards the relevant tea.Msg values to the child
+	// (see Message flow in
+	// make-lanes-its-own-child-widget.implementation-plan.issue-604.md).
+	track track.Model
 
 	// header is the supplementary flag info carried on the OvertureMsg.
 	// Stored on the model so renderFlagsRow and other renderers can
@@ -95,45 +98,32 @@ type Model struct {
 	bannerInfo BannerInfo
 }
 
-// initLaneSkip computes the per-lane skip factor from each lane's
-// IntervalMs. The skip factor = IntervalMs / tickRate (in ms). A lane
-// with no override (IntervalMs=0) gets factor 0 - it advances every
-// tick. A lane with IntervalMs=5000 at 50ms tick rate gets factor 100,
-// advancing one frame every 100 ticks (every 5 seconds).
-// See Lane.IntervalMs for the config override path.
-func initLaneSkip(lanes []Lane, tickRate time.Duration) []int {
-	factors := make([]int, len(lanes))
-	tickMs := int(tickRate.Milliseconds())
-	if tickMs == 0 {
-		tickMs = 50
-	}
-	for i, lane := range lanes {
-		if lane.IntervalMs > 0 {
-			factors[i] = lane.IntervalMs / tickMs
-			if factors[i] < 1 {
-				factors[i] = 1
-			}
-		}
-	}
-	return factors
-}
-
-func NewModel(lanes []Lane, tickRate time.Duration, rootPath string,
+// NewModel constructs a highway view Model. The lanes slice is
+// passed to the track child widget which owns it from then on.
+// The theme is split: a copy of the theme fields the track widget
+// needs is captured into track.WithTheme; the rest stay on the
+// root for chrome rendering.
+func NewModel(lanes []track.Lane, tickRate time.Duration, rootPath string,
 	maxDepth uint, theme contract.Theme, noRecurse bool) Model {
 	return Model{
-		lanes:     lanes,
-		skip:      initLaneSkip(lanes, tickRate),
-		tickRate:  tickRate,
-		noRecurse: noRecurse,
 		width:     80,
 		rootPath:  rootPath,
 		maxDepth:  maxDepth,
+		noRecurse: noRecurse,
+		tickRate:  tickRate,
 		theme:     theme,
-		counted:   make(map[string]bool),
 		status: status.New(
 			status.WithTheme(theme),
 			status.WithFields(statusFieldSet()),
 			status.WithWidth(10),
+		),
+		track: track.New(
+			track.WithLanes(lanes),
+			track.WithTheme(theme),
+			track.WithTickRate(tickRate),
+			track.WithMaxDepth(maxDepth),
+			track.WithNoRecurse(noRecurse),
+			track.WithWidth(80),
 		),
 	}
 }
@@ -150,6 +140,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		var cmd tea.Cmd
 		m.status, cmd = m.dispatchStatus(status.WidthMsg{Width: msg.Width})
+		m.track, _ = m.dispatchTrack(track.WidthMsg{Width: msg.Width})
 		return m, cmd
 
 	case tea.KeyMsg:
@@ -170,47 +161,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.start = core.Now()
 		}
 		m.totalTicks++
-		// Advance each lane's frame counter independently.
-		// Lanes with a skip factor > 0 (set via IntervalMs override)
-		// only advance their tick every N global ticks, producing a
-		// visibly slower animation. Lanes with skip factor 0 advance
-		// every tick (full speed).
-		for i := range m.lanes {
-			if m.skip != nil && i < len(m.skip) && m.skip[i] > 0 {
-				m.lanes[i].skipCounter++
-				if m.lanes[i].skipCounter >= m.skip[i] {
-					m.lanes[i].skipCounter = 0
-					m.lanes[i].tick++
-				}
-			} else {
-				m.lanes[i].tick++
-			}
-
-			// Advance gradient state for lanes with configured gradients.
-			// IMPORTANT: This updates the state (offset/index) but does NOT apply
-			// the gradient colours to frameContent - that happens in renderLanes().
-			// The GradientState.Offset tracks current position in gradient array;
-			// ApplyGradient() uses this offset to interpolate characters from Hi->Lo.
-			if m.lanes[i].HighlightGradient != nil {
-				windowSize := m.lanes[i].WindowSize()
-				if windowSize <= 0 {
-					windowSize = 4
-				}
-				m.lanes[i].GradientState.Update(windowSize)
-			}
-
-			if m.lanes[i].PeriscopeGradient != nil {
-				windowSize := m.lanes[i].WindowSize()
-				if windowSize <= 0 {
-					windowSize = 4
-				}
-				m.lanes[i].PeriscopeGradientState.Update(windowSize)
-			}
-		}
-
-		// Advance the banner's gradient state on its own slower tick
-		// so its warm glow is visibly different from the lane
-		// animations. skipFactor handles the speed difference.
+		// Forward the tick to the track child. Track advances
+		// each lane's tick counter, applies the per-lane skip
+		// factor and advances gradient states.
+		m.track, _ = m.dispatchTrack(track.TickMsg(time.Time(msg)))
+		// Advance the banner's gradient state on its own slower
+		// tick so its warm glow is visibly different from the
+		// lane animations. skipFactor handles the speed
+		// difference.
 		m.banner.advance()
 		tickCmd := tea.Tick(m.tickRate, func(t time.Time) tea.Msg {
 			return tickMsg(t)
@@ -232,11 +190,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// so the bar animates without real traversal
 				// data. In real mode the percent is driven by
 				// TotalMsg + IncDoneMsg (the done/total ratio).
-				// TODO(realMode-cleanup): once lanes becomes a
-				// proper child model and owns its own ticking,
-				// move the demo-mode fake percent generation
-				// into lanes.Update so the root doesn't need
-				// to know about it.
+				// TODO(realMode-cleanup): once the demo-mode
+				// fake percent generation moves into
+				// status.Update (or track.Update), the root
+				// no longer needs to know about it.
 				m.status, _ = m.dispatchStatus(status.PercentMsg{
 					Percent: int(elapsed.Seconds()) * 2 % 100,
 				})
@@ -282,6 +239,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.MaxDepth > m.maxDepth {
 			m.maxDepth = msg.MaxDepth
 		}
+		// Forward the max depth to the track child for the
+		// periscope bar fill formula. The track package only
+		// needs MaxDepth, not the file/dir counts (those stay
+		// at the root and go to the status widget).
+		m.track, _ = m.dispatchTrack(track.CensusMsg{MaxDepth: msg.MaxDepth})
 		// Forward the total to the status widget so it can
 		// compute the percent on its own. The total must include
 		// both files AND dirs because every MotifMsg (regardless
@@ -298,33 +260,59 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case MotifMsg:
-		isNew := !m.counted[msg.Data.Path]
-		if isNew {
-			m.counted[msg.Data.Path] = true
-			cmds := make([]tea.Cmd, 0, 1)
-			if msg.Data.IsDir {
-				m.dirs++
-			} else {
-				m.files++
-			}
-			// Forward the new count to the status widget so the
-			// percent / progress bar reflects the new total.
-			// TODO(lanes-widget-state-migration): the counted
-			// map, m.files and m.dirs will all move to the
-			// lanes child widget in a future PR; this
-			// translation will then happen inside lanes.Update
-			// and the root's local copies can be removed.
-			var cmd tea.Cmd
-			m.status, cmd = m.dispatchStatus(status.IncDoneMsg{N: 1})
-			if cmd != nil {
-				cmds = append(cmds, cmd)
-			}
-			m.status, _ = m.dispatchStatus(status.CountsMsg{
-				Files: m.files, Dirs: m.dirs, Errors: m.errors,
-			})
-			return m.applyMotifData(msg, cmds)
+		// Track the pre-dispatch file/dir counts so we can
+		// detect whether the motif was new (i.e. the track
+		// child's dedup map saw the path for the first time).
+		// Only motifs that are new should drive the status
+		// progress bar; duplicates still apply their data to
+		// the current lane but must NOT re-target the spring.
+		prevFiles := m.track.Files()
+		prevDirs := m.track.Dirs()
+
+		// Forward to the track child. Track dedupes on path,
+		// increments files/dirs (only on first sighting),
+		// applies the motif data to the current lane and
+		// rotates the lane index.
+		m.track, _ = m.dispatchTrack(track.MotifMsg{Data: track.MotifData{
+			Path:              msg.Data.Path,
+			Name:              msg.Data.Name,
+			IsDir:             msg.Data.IsDir,
+			Depth:             msg.Data.Depth,
+			ActionName:        msg.Data.ActionName,
+			PipelineName:      msg.Data.PipelineName,
+			CommandOutput:     msg.Data.CommandOutput,
+			ExecutionString:   msg.Data.ExecutionString,
+			DryRun:            msg.Data.DryRun,
+			Err:               msg.Data.Err,
+			JobEmoji:          msg.Data.JobEmoji,
+			Gradient:          msg.Data.Gradient,
+			PeriscopeGradient: msg.Data.PeriscopeGradient,
+		}})
+
+		// If neither files nor dirs changed, the path was a
+		// duplicate - the track child applied data to the
+		// current lane and rotated the index, but did not
+		// increment any counter, so the status widget must
+		// not see an IncDoneMsg.
+		isNew := m.track.Files() > prevFiles || m.track.Dirs() > prevDirs
+		if !isNew {
+			return m, nil
 		}
-		return m.applyMotifData(msg, nil)
+
+		// New motif: forward the increment to the status
+		// widget so the percent / progress bar reflects the
+		// new total. We read the post-update counts from the
+		// track child (track.Files() / track.Dirs()).
+		cmds := make([]tea.Cmd, 0, 1)
+		var cmd tea.Cmd
+		m.status, cmd = m.dispatchStatus(status.IncDoneMsg{N: 1})
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		m.status, _ = m.dispatchStatus(status.CountsMsg{
+			Files: m.track.Files(), Dirs: m.track.Dirs(), Errors: m.errors,
+		})
+		return m, tea.Batch(cmds...)
 
 	case CompleteMsg:
 		// Capture the first non-nil error message for the
@@ -340,9 +328,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.elapsed = msg.Elapsed
 		m.done = true
 
+		// Forward the flush signal to the track child so it
+		// clears its counted map. The track child does not need
+		// the file/dir counts (they are not displayed in any
+		// lane); those go to status via CountsMsg below.
+		m.track, _ = m.dispatchTrack(track.CompleteMsg{})
+
 		// Forward the final counts and elapsed to the status
 		// widget. The widget owns the percent calculation and
-		// the isDone flag from here on.
+		// the isDone flag from here on. The status DoneMsg
+		// handler only overwrites its errMsg when msg.Err is
+		// non-empty, so passing the root's potentially-empty
+		// errMsg is safe.
 		cmds := make([]tea.Cmd, 0, 2)
 		m.status, _ = m.dispatchStatus(status.CountsMsg{
 			Files: msg.Files, Dirs: msg.Dirs, Errors: len(msg.Errs),
@@ -382,46 +379,11 @@ func (m Model) dispatchStatus(msg tea.Msg) (status.Model, tea.Cmd) {
 	return r.(status.Model), cmd //nolint:errcheck // known concrete type
 }
 
-// applyMotifData updates the per-lane fields from a MotifMsg. The
-// caller is responsible for any status translation (IncDoneMsg,
-// CountsMsg) before calling this. Extracted from the MotifMsg
-// switch arm to keep the update flow readable.
-func (m Model) applyMotifData(msg MotifMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
-	if len(m.lanes) > 0 {
-		m.lanes[m.currentLaneIdx].JobEmoji = msg.Data.JobEmoji
-		m.lanes[m.currentLaneIdx].Path = msg.Data.Path
-		m.lanes[m.currentLaneIdx].Name = msg.Data.Name
-		m.lanes[m.currentLaneIdx].IsDir = msg.Data.IsDir
-		m.lanes[m.currentLaneIdx].Depth = msg.Data.Depth
-		m.lanes[m.currentLaneIdx].ActionName = msg.Data.ActionName
-		m.lanes[m.currentLaneIdx].PipelineName = msg.Data.PipelineName
-		m.lanes[m.currentLaneIdx].CommandOutput = msg.Data.CommandOutput
-		m.lanes[m.currentLaneIdx].ExecutionString = msg.Data.ExecutionString
-		m.lanes[m.currentLaneIdx].DryRun = msg.Data.DryRun
-		m.lanes[m.currentLaneIdx].Err = msg.Data.Err
-		// Copy gradient from message to lane if provided.
-		// The gradient is a ResolvedGradient {Steps, Hi, Lo} from the theme palette.
-		// It holds colour endpoint info; we apply it in renderLanes() using ApplyGradient().
-		if msg.Data.Gradient != nil {
-			m.lanes[m.currentLaneIdx].HighlightGradient = msg.Data.Gradient
-			// Also ensure GradientState exists and is configured with steps.
-			if m.lanes[m.currentLaneIdx].GradientState == nil {
-				m.lanes[m.currentLaneIdx].GradientState = effects.NewGradientState()
-			}
-			m.lanes[m.currentLaneIdx].GradientState.TotalSteps = msg.Data.Gradient.Steps
-		}
-
-		if msg.Data.PeriscopeGradient != nil {
-			m.lanes[m.currentLaneIdx].PeriscopeGradient = msg.Data.PeriscopeGradient
-			if m.lanes[m.currentLaneIdx].PeriscopeGradientState == nil {
-				m.lanes[m.currentLaneIdx].PeriscopeGradientState = effects.NewGradientState()
-			}
-			m.lanes[m.currentLaneIdx].PeriscopeGradientState.TotalSteps = msg.Data.PeriscopeGradient.Steps
-		}
-		m.currentLaneIdx = (m.currentLaneIdx + 1) % len(m.lanes)
-	}
-	if len(cmds) == 0 {
-		return m, nil
-	}
-	return m, tea.Batch(cmds...)
+// dispatchTrack forwards a track-owned message to the child track
+// widget and returns the resulting (track.Model, tea.Cmd) tuple.
+// The caller assigns the returned model back to m.track. Mirrors
+// dispatchStatus.
+func (m Model) dispatchTrack(msg tea.Msg) (track.Model, tea.Cmd) { //nolint:unparam // ok
+	r, cmd := m.track.Update(msg)
+	return r.(track.Model), cmd //nolint:errcheck // known concrete type
 }

--- a/src/prism/highway/model_test.go
+++ b/src/prism/highway/model_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/snivilised/jaywalk/src/prism/contract"
 	"github.com/snivilised/jaywalk/src/prism/movies"
 	"github.com/snivilised/jaywalk/src/prism/widgets/landing"
+	"github.com/snivilised/jaywalk/src/prism/widgets/track"
 )
 
 // ---------------------------------------------------------------------------
@@ -30,12 +31,14 @@ func testTheme() contract.Theme {
 
 func noopFrame(_ int) string { return "•" }
 
-func baseLane() Lane {
-	return Lane{Emoji: "🔍", JobEmoji: "🍎", Label: "test", FrameFn: noopFrame}
+func baseLane() track.Lane {
+	return track.Lane{
+		Emoji: "🔍", JobEmoji: "🍎", Label: "test", FrameFn: noopFrame,
+	}
 }
 
 func baseModel(lanes int) Model {
-	l := make([]Lane, lanes)
+	l := make([]track.Lane, lanes)
 	for i := range l {
 		l[i] = baseLane()
 	}
@@ -62,9 +65,9 @@ func invokeCmd(cmd tea.Cmd) tea.Msg {
 // ---------------------------------------------------------------------------
 
 var _ = Describe("NewModel", func() {
-	It("sets the lanes slice", func() {
+	It("sets the lanes slice on the track child", func() {
 		m := baseModel(3)
-		Expect(m.lanes).To(HaveLen(3))
+		Expect(m.track.Lanes()).To(HaveLen(3))
 	})
 
 	It("sets the tick rate", func() {
@@ -90,12 +93,6 @@ var _ = Describe("NewModel", func() {
 	It("stores the theme", func() {
 		m := baseModel(1)
 		Expect(m.theme).NotTo(Equal(contract.Theme{}))
-	})
-
-	It("initialises the counted map", func() {
-		m := baseModel(1)
-		Expect(m.counted).NotTo(BeNil())
-		Expect(m.counted).To(HaveLen(0))
 	})
 
 	It("initialises the status widget", func() {
@@ -153,6 +150,15 @@ var _ = Describe("Model.Update - WindowSizeMsg", func() {
 		Expect(cmd).To(BeNil())
 		Expect(updated.width).To(Equal(120))
 	})
+
+	It("forwards WidthMsg to the track child", func() {
+		m := baseModel(1)
+		// The track widget does not expose width directly, so
+		// the smoke check is that View produces a non-empty
+		// string at the new width.
+		updated, _ := update(m, tea.WindowSizeMsg{Width: 100})
+		Expect(updated.track.View().Content).NotTo(BeEmpty())
+	})
 })
 
 // ---------------------------------------------------------------------------
@@ -194,67 +200,20 @@ var _ = Describe("Model.Update - KeyMsg", func() {
 })
 
 // ---------------------------------------------------------------------------
-// initLaneSkip
-// ---------------------------------------------------------------------------
-
-var _ = Describe("initLaneSkip", func() {
-	It("returns zero factors when no lane has IntervalMs", func() {
-		lanes := []Lane{
-			{Emoji: "🔍", Label: "a", FrameFn: noopFrame},
-			{Emoji: "🔍", Label: "b", FrameFn: noopFrame},
-		}
-		factors := initLaneSkip(lanes, 50*time.Millisecond)
-		Expect(factors).To(HaveLen(2))
-		Expect(factors[0]).To(Equal(0))
-		Expect(factors[1]).To(Equal(0))
-	})
-
-	It("computes skip factor from IntervalMs / tickRate", func() {
-		lanes := []Lane{
-			{Emoji: "🔍", Label: "fast", FrameFn: noopFrame},
-			{Emoji: "🔍", Label: "slow", FrameFn: noopFrame, IntervalMs: 5000},
-			{Emoji: "🔍", Label: "medium", FrameFn: noopFrame, IntervalMs: 500},
-		}
-		// tickRate = 50ms → 5000/50 = 100, 500/50 = 10
-		factors := initLaneSkip(lanes, 50*time.Millisecond)
-		Expect(factors).To(HaveLen(3))
-		Expect(factors[0]).To(Equal(0))
-		Expect(factors[1]).To(Equal(100))
-		Expect(factors[2]).To(Equal(10))
-	})
-
-	It("defaults tickMs to 50 when zero", func() {
-		lanes := []Lane{
-			{Emoji: "🔍", Label: "slow", FrameFn: noopFrame, IntervalMs: 500},
-		}
-		factors := initLaneSkip(lanes, 0)
-		Expect(factors[0]).To(Equal(10))
-	})
-
-	It("clamps minimum skip factor to 1", func() {
-		lanes := []Lane{
-			{Emoji: "🔍", Label: "barely", FrameFn: noopFrame, IntervalMs: 25},
-		}
-		// 25/50 = 0 → clamped to 1
-		factors := initLaneSkip(lanes, 50*time.Millisecond)
-		Expect(factors[0]).To(Equal(1))
-	})
-})
-
-// ---------------------------------------------------------------------------
 // Model.Update - tickMsg
 // ---------------------------------------------------------------------------
 
 var _ = Describe("Model.Update - tickMsg", func() {
-	It("increments ticks on all lanes", func() {
+	It("forwards tickMsg to the track child, which advances lane ticks", func() {
 		m := baseModel(2)
-		Expect(m.lanes[0].tick).To(Equal(0))
-		Expect(m.lanes[1].tick).To(Equal(0))
+		Expect(m.track.Tick(0)).To(Equal(0))
+		Expect(m.track.Tick(1)).To(Equal(0))
 
 		updated, cmd := update(m, tickMsg(core.Now()))
-		Expect(updated.lanes[0].tick).To(Equal(1))
-		Expect(updated.lanes[1].tick).To(Equal(1))
-		_ = cmd
+		Expect(cmd).NotTo(BeNil(),
+			"root should reschedule the next tick (and possibly forward child cmds)")
+		Expect(updated.track.Tick(0)).To(Equal(1))
+		Expect(updated.track.Tick(1)).To(Equal(1))
 	})
 
 	It("reschedules the next tick when not done", func() {
@@ -293,9 +252,9 @@ var _ = Describe("Model.Update - tickMsg", func() {
 	})
 
 	It("advances slow lane fewer ticks than fast lane based on IntervalMs", func() {
-		fast := Lane{Emoji: "🔍", Label: "fast", FrameFn: noopFrame}
-		slow := Lane{Emoji: "🐢", Label: "slow", FrameFn: noopFrame, IntervalMs: 500}
-		lanes := []Lane{fast, slow}
+		fast := track.Lane{Emoji: "🔍", Label: "fast", FrameFn: noopFrame}
+		slow := track.Lane{Emoji: "🐢", Label: "slow", FrameFn: noopFrame, IntervalMs: 500}
+		lanes := []track.Lane{fast, slow}
 		m := NewModel(lanes, 50*time.Millisecond, "/root", 5, testTheme(), false)
 
 		// After 10 ticks at 50ms:
@@ -304,23 +263,8 @@ var _ = Describe("Model.Update - tickMsg", func() {
 		for range 10 {
 			m, _ = update(m, tickMsg(core.Now()))
 		}
-		Expect(m.lanes[0].tick).To(Equal(10), "fast lane should advance every tick")
-		Expect(m.lanes[1].tick).To(Equal(1), "slow lane should advance every 10th tick")
-	})
-
-	It("respects different intervals per lane", func() {
-		fast := Lane{Emoji: "🔍", Label: "fast", FrameFn: noopFrame}
-		medium := Lane{Emoji: "⚡", Label: "medium", FrameFn: noopFrame, IntervalMs: 200}
-		verySlow := Lane{Emoji: contract.Static.Emoji.Snail, Label: "very-slow", FrameFn: noopFrame, IntervalMs: 5000}
-		lanes := []Lane{fast, medium, verySlow}
-		m := NewModel(lanes, 50*time.Millisecond, "/root", 5, testTheme(), false)
-
-		for range 100 {
-			m, _ = update(m, tickMsg(core.Now()))
-		}
-		Expect(m.lanes[0].tick).To(Equal(100), "fast: every tick")
-		Expect(m.lanes[1].tick).To(Equal(25), "medium: 200/50=4, 100/4=25")
-		Expect(m.lanes[2].tick).To(Equal(1), "very-slow: 5000/50=100, 100/100=1")
+		Expect(m.track.Tick(0)).To(Equal(10), "fast lane should advance every tick")
+		Expect(m.track.Tick(1)).To(Equal(1), "slow lane should advance every 10th tick")
 	})
 
 	It("pushes elapsed to the status widget in real mode on every tick", func() {
@@ -453,6 +397,12 @@ var _ = Describe("Model.Update - CensusMsg", func() {
 		Expect(updated.maxDepth).To(Equal(uint(10)))
 	})
 
+	It("forwards MaxDepth to the track child", func() {
+		m := baseModel(1)
+		updated, _ := update(m, CensusMsg{TotalFiles: 5, MaxDepth: 12})
+		Expect(updated.track.MaxDepth()).To(Equal(uint(12)))
+	})
+
 	It("does not decrease maxDepth", func() {
 		m := baseModel(1)
 		Expect(m.maxDepth).To(Equal(uint(5)))
@@ -470,7 +420,7 @@ var _ = Describe("Model.Update - CensusMsg", func() {
 var _ = Describe("Model.Update - MotifMsg", func() {
 	It("updates the current lane and advances the index round-robin", func() {
 		m := baseModel(2)
-		Expect(m.currentLaneIdx).To(Equal(0))
+		Expect(m.track.CurrentLaneIdx()).To(Equal(0))
 
 		first := MotifMsg{Data: MotifData{
 			Path: "/root/a.txt", Name: "a.txt", IsDir: false, Depth: 1,
@@ -478,38 +428,42 @@ var _ = Describe("Model.Update - MotifMsg", func() {
 		updated1, _ := update(m, first)
 		// cmd is the status spring's first-frame cmd; the
 		// MotifMsg increment re-targets the bar to (done/total).
-		Expect(updated1.lanes[0].Path).To(Equal("/root/a.txt"))
-		Expect(updated1.lanes[0].Name).To(Equal("a.txt"))
-		Expect(updated1.lanes[0].IsDir).To(BeFalse())
-		Expect(updated1.lanes[0].Depth).To(Equal(uint(1)))
-		Expect(updated1.currentLaneIdx).To(Equal(1))
+		Expect(updated1.track.Lanes()[0].Path).To(Equal("/root/a.txt"))
+		Expect(updated1.track.Lanes()[0].Name).To(Equal("a.txt"))
+		Expect(updated1.track.Lanes()[0].IsDir).To(BeFalse())
+		Expect(updated1.track.Lanes()[0].Depth).To(Equal(uint(1)))
+		Expect(updated1.track.CurrentLaneIdx()).To(Equal(1))
 
 		second := MotifMsg{Data: MotifData{
 			Path: "/root/b.txt", Name: "b.txt", IsDir: false, Depth: 2,
 		}}
 		updated2, _ := update(updated1, second)
-		Expect(updated2.lanes[1].Path).To(Equal("/root/b.txt"))
-		Expect(updated2.currentLaneIdx).To(Equal(0))
+		Expect(updated2.track.Lanes()[1].Path).To(Equal("/root/b.txt"))
+		Expect(updated2.track.CurrentLaneIdx()).To(Equal(0))
 
 		// Third wraps around to lane 0
 		third := MotifMsg{Data: MotifData{
 			Path: "/root/c.txt", Name: "c.txt", IsDir: false, Depth: 3,
 		}}
 		updated3, _ := update(updated2, third)
-		Expect(updated3.lanes[0].Path).To(Equal("/root/c.txt"))
-		Expect(updated3.currentLaneIdx).To(Equal(1))
+		Expect(updated3.track.Lanes()[0].Path).To(Equal("/root/c.txt"))
+		Expect(updated3.track.CurrentLaneIdx()).To(Equal(1))
 	})
 
 	It("counts each unique path once for progress", func() {
 		m := baseModel(1)
-		m.totalFiles = 10
-		Expect(m.files).To(Equal(0))
+		updated, _ := update(m, CensusMsg{TotalFiles: 10})
+		// totalFiles = 10, but the new code seeds
+		// status.Total() with TotalFiles + TotalDirs. With
+		// TotalDirs = 0, total = 10.
+		Expect(updated.status.Total()).To(Equal(10))
 
 		// First unique path
-		updated, _ := update(m, MotifMsg{Data: MotifData{
+		updated, _ = update(m, MotifMsg{Data: MotifData{
 			Path: "/root/a.txt", IsDir: false,
 		}})
-		Expect(updated.files).To(Equal(1))
+		Expect(updated.track.Files()).To(Equal(1))
+		Expect(updated.status.Done()).To(Equal(1))
 
 		// Same path again - not counted (no IncDoneMsg, no
 		// spring re-target, cmd is nil).
@@ -517,24 +471,24 @@ var _ = Describe("Model.Update - MotifMsg", func() {
 			Path: "/root/a.txt", IsDir: false,
 		}})
 		Expect(cmd).To(BeNil(), "duplicate path must not re-target the spring")
-		Expect(updated.files).To(Equal(1))
+		Expect(updated.track.Files()).To(Equal(1))
 
 		// Different path - counted
 		updated, _ = update(updated, MotifMsg{Data: MotifData{
 			Path: "/root/b.txt", IsDir: false,
 		}})
-		Expect(updated.files).To(Equal(2))
+		Expect(updated.track.Files()).To(Equal(2))
 	})
 
 	It("increments dirs for directories", func() {
 		m := baseModel(1)
-		Expect(m.dirs).To(Equal(0))
+		Expect(m.track.Dirs()).To(Equal(0))
 
 		updated, _ := update(m, MotifMsg{Data: MotifData{
 			Path: "/root/src", IsDir: true,
 		}})
-		Expect(updated.dirs).To(Equal(1))
-		Expect(updated.files).To(Equal(0))
+		Expect(updated.track.Dirs()).To(Equal(1))
+		Expect(updated.track.Files()).To(Equal(0))
 	})
 
 	It("sets action and pipeline info on the lane", func() {
@@ -546,12 +500,12 @@ var _ = Describe("Model.Update - MotifMsg", func() {
 			Err: errors.New("boom"),
 		}})
 
-		Expect(updated.lanes[0].ActionName).To(Equal("encode"))
-		Expect(updated.lanes[0].PipelineName).To(Equal("pipe"))
-		Expect(updated.lanes[0].CommandOutput).To(Equal("ok"))
-		Expect(updated.lanes[0].ExecutionString).To(Equal("ffmpeg"))
-		Expect(updated.lanes[0].DryRun).To(BeTrue())
-		Expect(updated.lanes[0].Err).To(MatchError("boom"))
+		Expect(updated.track.Lanes()[0].ActionName).To(Equal("encode"))
+		Expect(updated.track.Lanes()[0].PipelineName).To(Equal("pipe"))
+		Expect(updated.track.Lanes()[0].CommandOutput).To(Equal("ok"))
+		Expect(updated.track.Lanes()[0].ExecutionString).To(Equal("ffmpeg"))
+		Expect(updated.track.Lanes()[0].DryRun).To(BeTrue())
+		Expect(updated.track.Lanes()[0].Err).To(MatchError("boom"))
 	})
 
 	It("computes percent during navigation from done/total", func() {

--- a/src/prism/highway/view.go
+++ b/src/prism/highway/view.go
@@ -22,7 +22,12 @@ func (m Model) View() tea.View {
 	if m.FlagsRowPosition == FlagsRowPositionTop {
 		m.renderFlagsRow(&b)
 	}
-	m.renderLanes(&b)
+
+	// Lane rows + separators come from the track child. The track
+	// widget is a self-contained bubbletea Model that owns its
+	// own styling and rendering.
+	b.WriteString(m.track.View().Content)
+
 	if m.FlagsRowPosition == FlagsRowPositionBottom || m.FlagsRowPosition == "" {
 		m.renderFlagsRow(&b)
 	}

--- a/src/prism/widgets/track/messages.go
+++ b/src/prism/widgets/track/messages.go
@@ -1,0 +1,75 @@
+package track
+
+import (
+	"time"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+)
+
+// Messages understood only by Model.Update. The track widget knows
+// nothing about highway's OvertureMsg / BannerInfo vocabulary; the
+// highway root translates them into the messages defined here.
+
+// TickMsg is the per-tick forward from the highway root. The
+// root drives tea.Tick (it owns the ticker) and wraps the
+// time.Time payload in TickMsg before forwarding to the track
+// child. The child uses the payload only as a signal; the
+// payload value is not interpreted.
+type TickMsg time.Time
+
+// WidthMsg updates the rendered row width. The root forwards
+// tea.WindowSizeMsg as WidthMsg so the per-lane layout re-flows.
+type WidthMsg struct {
+	Width int
+}
+
+// MotifMsg carries a single per-node event into the widget. The
+// widget applies the data to the current lane, advances
+// currentLaneIdx round-robin, dedups on Path, and increments
+// files/dirs.
+type MotifMsg struct {
+	Data MotifData
+}
+
+// MotifData is the per-node payload. Moved verbatim from the
+// highway package.
+type MotifData struct {
+	Path            string
+	Name            string
+	IsDir           bool
+	Depth           uint
+	ActionName      string
+	PipelineName    string
+	CommandOutput   string
+	ExecutionString string
+	DryRun          bool
+	Err             error
+
+	// JobEmoji is the emoji associated with the incoming job,
+	// rendered after the periscope bar.
+	JobEmoji string
+
+	// Gradient is the optional animation gradient to apply to
+	// this lane's frame. Populated when
+	// HighwayConfig.AnimationGradient is set in config; nil
+	// otherwise.
+	Gradient *contract.ResolvedGradient
+
+	// PeriscopeGradient is the optional gradient for this lane's
+	// periscope bar. Looked up via
+	// theme.GradientFor(GradientComponentPeriscope) in sendMotif.
+	PeriscopeGradient *contract.ResolvedGradient
+}
+
+// CensusMsg declares the maximum tree depth observed during the
+// preview pass. Used by the periscope bar fill formula. TotalFiles
+// and TotalDirs stay in the highway-level CensusMsg because the
+// status widget (not track) needs them for the progress bar.
+type CensusMsg struct {
+	MaxDepth uint
+}
+
+// CompleteMsg is a flush signal: the root has signalled end of
+// navigation. The track widget clears its counted map so any
+// further MotifMsg re-becomes a no-op dedup-wise.
+type CompleteMsg struct{}

--- a/src/prism/widgets/track/model.go
+++ b/src/prism/widgets/track/model.go
@@ -1,0 +1,196 @@
+package track
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+)
+
+// defaultTickMs is the global tick rate used when WithTickRate is
+// not supplied. Matches the implicit 50ms default the highway model
+// used previously.
+const defaultTickMs = 50
+
+// LaneBarWidth is the width of the square depth bar rendered in
+// each lane of the highway view. Mirrors the constant previously
+// declared in the highway package.
+const LaneBarWidth = 10
+
+// SpinnerNameWidth is the fixed width allocated for the spinner
+// name column in each lane. Names shorter than this are
+// right-padded so all following columns stay aligned. Mirrors the
+// constant previously declared in the highway package.
+const SpinnerNameWidth = 18
+
+// Model is the bubbletea Model for the track widget. It owns the
+// per-lane animation state, the per-tick advance, the motif-data
+// application, the deduplication map, and the per-lane rendering.
+// The widget does NOT own its ticker; the highway root drives
+// tea.Tick and forwards TickMsg to Update.
+type Model struct {
+	lanes          []Lane
+	skip           []int
+	width          int
+	currentLaneIdx int
+	counted        map[string]bool
+	files          int
+	dirs           int
+	maxDepth       uint
+	noRecurse      bool
+	tickRate       time.Duration
+	styles         Styles
+}
+
+// Option configures Model at construction time. Mirrors the
+// status.Option pattern.
+type Option func(*Model)
+
+// WithLanes sets the initial lane slice and computes the per-lane
+// skip factors based on the currently-supplied tick rate. The
+// order of options matters: WithTickRate should appear before
+// WithLanes if both are used. When WithLanes is called more than
+// once, the most recent call wins and skip is recomputed.
+func WithLanes(lanes []Lane) Option {
+	return func(m *Model) {
+		m.lanes = lanes
+		m.skip = initLaneSkip(lanes, m.tickRate)
+		m.counted = make(map[string]bool)
+		m.currentLaneIdx = 0
+	}
+}
+
+// WithTickRate sets the global tick rate used for skip-factor
+// computation. A zero or negative value falls back to 50ms.
+func WithTickRate(rate time.Duration) Option {
+	return func(m *Model) {
+		if rate <= 0 {
+			rate = defaultTickMs * time.Millisecond
+		}
+		m.tickRate = rate
+		// Recompute skip if lanes are already set; the caller may
+		// also have supplied them before the rate.
+		if m.lanes != nil {
+			m.skip = initLaneSkip(m.lanes, m.tickRate)
+		}
+	}
+}
+
+// WithMaxDepth sets the maximum tree depth observed during the
+// preview pass. Used by the periscope bar fill formula.
+func WithMaxDepth(d uint) Option {
+	return func(m *Model) { m.maxDepth = d }
+}
+
+// WithNoRecurse sets the no-recurse flag. When true the periscope
+// bar renders as a single filled glyph (no animation, no depth
+// fill calculation).
+func WithNoRecurse(b bool) Option {
+	return func(m *Model) { m.noRecurse = b }
+}
+
+// WithWidth sets the initial layout width. Updated again on
+// receipt of WidthMsg.
+func WithWidth(w int) Option {
+	return func(m *Model) { m.width = w }
+}
+
+// WithStyles sets the lipgloss styles used at render time. When
+// also calling WithTheme, WithTheme wins for fields it populates.
+func WithStyles(s Styles) Option {
+	return func(m *Model) { m.styles = s }
+}
+
+// WithTheme populates Styles from a resolved theme. This is the
+// recommended way to construct the widget from the highway view.
+func WithTheme(t contract.Theme) Option {
+	return func(m *Model) {
+		m.styles = Styles{
+			BarFilledStyle:    t.BarFilledStyle,
+			BarEmptyStyle:     t.BarEmptyStyle,
+			ErrorStyle:        t.ErrorStyle,
+			ActionStyle:       t.ActionStyle,
+			PipelineStyle:     t.PipelineStyle,
+			DirStyle:          t.DirStyle,
+			FileStyle:         t.FileStyle,
+			MutedStyle:        t.MutedStyle,
+			TreeIcons:         t.TreeIcons,
+			FrameStyle:        t.FrameStyle,
+			BorderStyle:       t.BorderStyle,
+			BranchStyle:       t.BranchStyle,
+			LandingStripStyle: t.LandingStripStyle,
+		}
+	}
+}
+
+// New constructs a Model with the supplied options. The default
+// tick rate is 50ms; the default width is 0 (caller is expected to
+// send a WidthMsg before View).
+func New(opts ...Option) Model {
+	m := Model{
+		tickRate: defaultTickMs * time.Millisecond,
+	}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return m
+}
+
+// Init returns nil. The highway root drives tea.Tick; the widget
+// does not start its own timer. This mirrors the status widget
+// pattern.
+func (m Model) Init() tea.Cmd { return nil }
+
+// Files returns the current files count. Set by MotifMsg
+// processing (one increment per unique non-dir path).
+func (m Model) Files() int { return m.files }
+
+// Dirs returns the current directories count. Set by MotifMsg
+// processing (one increment per unique dir path).
+func (m Model) Dirs() int { return m.dirs }
+
+// Lanes returns the current lane slice. Read-only accessor for
+// tests and callers that need to inspect lane state directly.
+func (m Model) Lanes() []Lane { return m.lanes }
+
+// Tick returns the current frame tick of the lane at idx. The
+// tick advances on every TickMsg for lanes with IntervalMs=0
+// (skip factor 0) and on every Nth tick for lanes with a skip
+// factor of N. Exposed for tests.
+func (m Model) Tick(idx int) int {
+	if idx < 0 || idx >= len(m.lanes) {
+		return 0
+	}
+	return m.lanes[idx].tick
+}
+
+// CurrentLaneIdx returns the index of the lane that the next
+// MotifMsg would write to. Exposed for tests.
+func (m Model) CurrentLaneIdx() int { return m.currentLaneIdx }
+
+// MaxDepth returns the maximum tree depth observed via CensusMsg.
+func (m Model) MaxDepth() uint { return m.maxDepth }
+
+// initLaneSkip computes the per-lane skip factor from each lane's
+// IntervalMs. The skip factor = IntervalMs / tickRate (in ms). A
+// lane with no override (IntervalMs=0) gets factor 0 - it advances
+// every tick. A lane with IntervalMs=5000 at 50ms tick rate gets
+// factor 100, advancing one frame every 100 ticks (every 5
+// seconds). Moved verbatim from highway.initLaneSkip.
+func initLaneSkip(lanes []Lane, tickRate time.Duration) []int {
+	factors := make([]int, len(lanes))
+	tickMs := int(tickRate.Milliseconds())
+	if tickMs == 0 {
+		tickMs = defaultTickMs
+	}
+	for i, lane := range lanes {
+		if lane.IntervalMs > 0 {
+			factors[i] = lane.IntervalMs / tickMs
+			if factors[i] < 1 {
+				factors[i] = 1
+			}
+		}
+	}
+	return factors
+}

--- a/src/prism/widgets/track/styles.go
+++ b/src/prism/widgets/track/styles.go
@@ -1,0 +1,26 @@
+package track
+
+import (
+	"charm.land/lipgloss/v2"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+)
+
+// Styles holds the lipgloss styles used by the track widget at
+// render time. Populated either directly via WithStyles or from a
+// resolved theme via WithTheme. Mirrors the status.Styles pattern.
+type Styles struct {
+	BarFilledStyle    lipgloss.Style
+	BarEmptyStyle     lipgloss.Style
+	ErrorStyle        lipgloss.Style
+	ActionStyle       lipgloss.Style
+	PipelineStyle     lipgloss.Style
+	DirStyle          lipgloss.Style
+	FileStyle         lipgloss.Style
+	MutedStyle        lipgloss.Style
+	TreeIcons         contract.TreeIcons
+	FrameStyle        lipgloss.Style
+	BorderStyle       lipgloss.Style
+	BranchStyle       lipgloss.Style
+	LandingStripStyle lipgloss.Style
+}

--- a/src/prism/widgets/track/track-suite_test.go
+++ b/src/prism/widgets/track/track-suite_test.go
@@ -1,0 +1,13 @@
+package track
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTrack(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Track Suite")
+}

--- a/src/prism/widgets/track/track.go
+++ b/src/prism/widgets/track/track.go
@@ -1,11 +1,13 @@
-package highway
+package track
 
 import (
 	"github.com/snivilised/jaywalk/src/prism/contract"
 	"github.com/snivilised/jaywalk/src/prism/effects"
 )
 
-// Lane
+// Lane holds the per-worker state for a single track lane. The
+// highway root constructs the initial slice and the track widget
+// owns the per-tick and per-motif updates from there on.
 type Lane struct {
 	Emoji           string
 	JobEmoji        string
@@ -49,16 +51,23 @@ type Lane struct {
 	PeriscopeGradientState *effects.GradientState
 }
 
+// WindowSize returns the gradient window size appropriate for the
+// lane's current content. The same heuristic that previously lived
+// on the highway Lane type: command output length when present,
+// otherwise 6 for action animations on files, otherwise 4.
 func (l *Lane) WindowSize() int {
 	if len(l.CommandOutput) > 0 {
-		return len([]rune(l.CommandOutput)) // use command output width
+		return len([]rune(l.CommandOutput))
 	}
 	if l.ActionName != "" && !l.IsDir {
-		return 6 // default window size for action animations
+		return 6
 	}
-	return 4 // default window size
+	return 4
 }
 
+// ResetGradient re-initialises the highlight gradient state pointer
+// (creating one if absent) and resets it. Used when the same lane
+// starts a new motif cycle.
 func (l *Lane) ResetGradient() {
 	if l.GradientState == nil {
 		l.GradientState = effects.NewGradientState()

--- a/src/prism/widgets/track/track_test.go
+++ b/src/prism/widgets/track/track_test.go
@@ -1,0 +1,512 @@
+package track
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/snivilised/jaywalk/src/prism/contract"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func testTheme() contract.Theme {
+	t, err := contract.NewTheme(contract.SystemPalette(), io.Discard)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func noopFrame(_ int) string { return "•" }
+
+func baseLane() Lane {
+	return Lane{
+		Emoji: "🔍", JobEmoji: "🍎", Label: "test", FrameFn: noopFrame,
+	}
+}
+
+func baseModel(lanes int) Model {
+	l := make([]Lane, lanes)
+	for i := range l {
+		l[i] = baseLane()
+	}
+	return New(
+		WithLanes(l),
+		WithTheme(testTheme()),
+		WithTickRate(50*time.Millisecond),
+		WithMaxDepth(5),
+		WithWidth(80),
+	)
+}
+
+// update is a convenience wrapper that casts the bubbletea Model
+// back to Model. Mirrors the helper used in
+// src/prism/highway/model_test.go.
+func update(m Model, msg tea.Msg) (Model, tea.Cmd) {
+	r, cmd := m.Update(msg)
+	return r.(Model), cmd //nolint:errcheck // known concrete type
+}
+
+// tickNow returns a fresh TickMsg value.
+func tickNow() TickMsg { return TickMsg(time.Now()) }
+
+// countOccurrences counts the non-overlapping occurrences of sub
+// in s.
+func countOccurrences(s, sub string) int {
+	count := 0
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			count++
+		}
+	}
+	return count
+}
+
+// ---------------------------------------------------------------------------
+// New
+// ---------------------------------------------------------------------------
+
+var _ = Describe("New", func() {
+	It("sets the lanes slice", func() {
+		m := baseModel(3)
+		Expect(m.lanes).To(HaveLen(3))
+	})
+
+	It("initialises the counted map to empty (verified by MotifMsg behaviour)", func() {
+		m := baseModel(1)
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path: "/a", IsDir: false,
+		}})
+		Expect(updated.files).To(Equal(1))
+	})
+
+	It("initialises currentLaneIdx to 0", func() {
+		m := baseModel(1)
+		Expect(m.currentLaneIdx).To(Equal(0))
+	})
+
+	It("initialises tickRate to the supplied value", func() {
+		m := New(WithTickRate(25 * time.Millisecond))
+		Expect(m.tickRate).To(Equal(25 * time.Millisecond))
+	})
+
+	It("falls back to 50ms when WithTickRate receives a non-positive value", func() {
+		m := New(WithTickRate(0))
+		Expect(m.tickRate).To(Equal(50 * time.Millisecond))
+
+		m = New(WithTickRate(-1 * time.Millisecond))
+		Expect(m.tickRate).To(Equal(50 * time.Millisecond))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Options", func() {
+	It("WithLanes computes the skip factor via the current tick rate", func() {
+		fast := baseLane()
+		slow := baseLane()
+		slow.IntervalMs = 500 // 500/50 = 10
+
+		m := New(
+			WithTickRate(50*time.Millisecond),
+			WithLanes([]Lane{fast, slow}),
+		)
+		// After 10 ticks, fast should be at 10 and slow at 1.
+		for range 10 {
+			m, _ = update(m, tickNow())
+		}
+		Expect(m.lanes[0].tick).To(Equal(10))
+		Expect(m.lanes[1].tick).To(Equal(1))
+	})
+
+	It("WithLanes default tick rate is 50ms when WithTickRate is omitted", func() {
+		lane := baseLane()
+		lane.IntervalMs = 100 // 100/50 = 2
+		m := New(WithLanes([]Lane{lane}))
+		for range 4 {
+			m, _ = update(m, tickNow())
+		}
+		Expect(m.lanes[0].tick).To(Equal(2))
+	})
+
+	It("WithTheme populates Styles from a resolved theme", func() {
+		m := New(
+			WithLanes([]Lane{baseLane()}),
+			WithTheme(testTheme()),
+		)
+		// styles should be non-zero after WithTheme.
+		Expect(m.styles.BarFilledStyle).NotTo(Equal(lipgloss.NewStyle()))
+	})
+
+	It("WithStyles overrides individual style fields", func() {
+		muted := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+		m := New(
+			WithLanes([]Lane{baseLane()}),
+			WithStyles(Styles{MutedStyle: muted}),
+		)
+		Expect(m.styles.MutedStyle.GetForeground()).NotTo(BeNil())
+	})
+
+	It("WithTheme after WithStyles wins for fields it populates", func() {
+		muted := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+		m := New(
+			WithLanes([]Lane{baseLane()}),
+			WithStyles(Styles{MutedStyle: muted}),
+			WithTheme(testTheme()),
+		)
+		// WithTheme re-assigns styles.MutedStyle, so the
+		// WithStyles colour should be gone.
+		// (We can't easily assert the colour value, but we
+		// can assert the style isn't the literal one we
+		// created via WithStyles.)
+		_ = muted
+		Expect(m.styles.MutedStyle).NotTo(Equal(muted))
+	})
+
+	It("WithMaxDepth sets the max depth", func() {
+		m := New(WithMaxDepth(7))
+		Expect(m.maxDepth).To(Equal(uint(7)))
+	})
+
+	It("WithNoRecurse sets the no-recurse flag", func() {
+		m := New(WithNoRecurse(true))
+		Expect(m.noRecurse).To(BeTrue())
+	})
+
+	It("WithWidth sets the initial width", func() {
+		m := New(WithWidth(120))
+		Expect(m.width).To(Equal(120))
+	})
+
+	It("WithTickRate recomputes skip when lanes are already set", func() {
+		lane := baseLane()
+		lane.IntervalMs = 100
+		// Set lanes first with a 50ms rate; skip = 2.
+		m := New(WithLanes([]Lane{lane}))
+		// Now switch to 25ms; skip recomputes to 4.
+		m2 := New(WithLanes([]Lane{lane}), WithTickRate(25*time.Millisecond))
+		Expect(m2.skip[0]).To(Equal(4))
+		Expect(m.skip[0]).To(Equal(2))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Model.Init
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Model.Init", func() {
+	It("returns nil (the highway root owns the ticker)", func() {
+		m := baseModel(1)
+		Expect(m.Init()).To(BeNil())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Model.Update - WidthMsg
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Model.Update - WidthMsg", func() {
+	It("updates the width", func() {
+		m := baseModel(1)
+		updated, cmd := update(m, WidthMsg{Width: 120})
+		Expect(cmd).To(BeNil())
+		Expect(updated.width).To(Equal(120))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Model.Update - tickMsg
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Model.Update - TickMsg", func() {
+	It("increments ticks on all lanes", func() {
+		m := baseModel(2)
+		Expect(m.lanes[0].tick).To(Equal(0))
+		Expect(m.lanes[1].tick).To(Equal(0))
+
+		updated, cmd := update(m, tickNow())
+		Expect(cmd).To(BeNil())
+		Expect(updated.lanes[0].tick).To(Equal(1))
+		Expect(updated.lanes[1].tick).To(Equal(1))
+	})
+
+	It("respects the skip factor on slow lanes", func() {
+		fast := baseLane()
+		slow := baseLane()
+		slow.IntervalMs = 500
+		m := New(
+			WithTickRate(50*time.Millisecond),
+			WithLanes([]Lane{fast, slow}),
+		)
+		for range 10 {
+			m, _ = update(m, tickNow())
+		}
+		Expect(m.lanes[0].tick).To(Equal(10))
+		Expect(m.lanes[1].tick).To(Equal(1))
+	})
+
+	It("advances a very slow lane exactly once in 100 ticks", func() {
+		very := baseLane()
+		very.IntervalMs = 5000 // 5000/50 = 100
+		m := New(
+			WithTickRate(50*time.Millisecond),
+			WithLanes([]Lane{very}),
+		)
+		for range 100 {
+			m, _ = update(m, tickNow())
+		}
+		Expect(m.lanes[0].tick).To(Equal(1))
+	})
+
+	It("returns no cmd (root drives the next tick)", func() {
+		m := baseModel(1)
+		_, cmd := update(m, tickNow())
+		Expect(cmd).To(BeNil())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Model.Update - MotifMsg
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Model.Update - MotifMsg", func() {
+	It("applies motif data to the current lane", func() {
+		m := baseModel(2)
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path: "/root/a.txt", Name: "a.txt", IsDir: false, Depth: 1,
+		}})
+		Expect(updated.lanes[0].Path).To(Equal("/root/a.txt"))
+		Expect(updated.lanes[0].Name).To(Equal("a.txt"))
+		Expect(updated.lanes[0].IsDir).To(BeFalse())
+		Expect(updated.lanes[0].Depth).To(Equal(uint(1)))
+	})
+
+	It("rotates currentLaneIdx round-robin", func() {
+		m := baseModel(2)
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path: "/root/a.txt", IsDir: false,
+		}})
+		Expect(updated.currentLaneIdx).To(Equal(1))
+
+		updated, _ = update(updated, MotifMsg{Data: MotifData{
+			Path: "/root/b.txt", IsDir: false,
+		}})
+		Expect(updated.lanes[1].Path).To(Equal("/root/b.txt"))
+		Expect(updated.currentLaneIdx).To(Equal(0))
+	})
+
+	It("dedupes via the counted map", func() {
+		m := baseModel(1)
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path: "/root/a.txt", IsDir: false,
+		}})
+		Expect(updated.files).To(Equal(1))
+
+		// Same path again - no increment.
+		updated, _ = update(updated, MotifMsg{Data: MotifData{
+			Path: "/root/a.txt", IsDir: false,
+		}})
+		Expect(updated.files).To(Equal(1))
+
+		// Different path - incremented.
+		updated, _ = update(updated, MotifMsg{Data: MotifData{
+			Path: "/root/b.txt", IsDir: false,
+		}})
+		Expect(updated.files).To(Equal(2))
+	})
+
+	It("increments Dirs for directories", func() {
+		m := baseModel(1)
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path: "/root/src", IsDir: true,
+		}})
+		Expect(updated.dirs).To(Equal(1))
+		Expect(updated.files).To(Equal(0))
+	})
+
+	It("sets action and pipeline info on the lane", func() {
+		m := baseModel(1)
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path:            "/f.txt",
+			ActionName:      "encode",
+			PipelineName:    "pipe",
+			CommandOutput:   "ok",
+			ExecutionString: "ffmpeg",
+			DryRun:          true,
+			Err:             errors.New("boom"),
+		}})
+		Expect(updated.lanes[0].ActionName).To(Equal("encode"))
+		Expect(updated.lanes[0].PipelineName).To(Equal("pipe"))
+		Expect(updated.lanes[0].CommandOutput).To(Equal("ok"))
+		Expect(updated.lanes[0].ExecutionString).To(Equal("ffmpeg"))
+		Expect(updated.lanes[0].DryRun).To(BeTrue())
+		Expect(updated.lanes[0].Err).To(MatchError("boom"))
+	})
+
+	It("handles zero lanes gracefully (counted still increments)", func() {
+		m := baseModel(0)
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path: "/root/f.txt",
+		}})
+		// Files still increments because the dedup is
+		// independent of lane application.
+		Expect(updated.files).To(Equal(1))
+	})
+
+	It("applies gradient to the lane and initialises GradientState", func() {
+		m := baseModel(1)
+		grad := &contract.ResolvedGradient{
+			Steps: 5, Hi: lipgloss.Color("#FF0000"), Lo: lipgloss.Color("#000000"),
+		}
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path:     "/f.txt",
+			Gradient: grad,
+		}})
+		Expect(updated.lanes[0].HighlightGradient).To(Equal(grad))
+		Expect(updated.lanes[0].GradientState).NotTo(BeNil())
+		Expect(updated.lanes[0].GradientState.TotalSteps).To(Equal(5))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Model.Update - CensusMsg
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Model.Update - CensusMsg", func() {
+	It("increases maxDepth when a larger value is seen", func() {
+		m := baseModel(1)
+		Expect(m.maxDepth).To(Equal(uint(5)))
+
+		updated, _ := update(m, CensusMsg{MaxDepth: 10})
+		Expect(updated.maxDepth).To(Equal(uint(10)))
+	})
+
+	It("does not decrease maxDepth", func() {
+		m := baseModel(1)
+		Expect(m.maxDepth).To(Equal(uint(5)))
+
+		updated, _ := update(m, CensusMsg{MaxDepth: 3})
+		Expect(updated.maxDepth).To(Equal(uint(5)))
+	})
+
+	It("returns no cmd", func() {
+		m := baseModel(1)
+		_, cmd := update(m, CensusMsg{MaxDepth: 7})
+		Expect(cmd).To(BeNil())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Model.Update - CompleteMsg
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Model.Update - CompleteMsg", func() {
+	It("clears the counted map so subsequent motifs increment again", func() {
+		m := baseModel(1)
+		updated, _ := update(m, MotifMsg{Data: MotifData{
+			Path: "/root/a.txt", IsDir: false,
+		}})
+		Expect(updated.files).To(Equal(1))
+
+		updated, _ = update(updated, CompleteMsg{})
+		// Same path after CompleteMsg: dedup map is empty,
+		// so this is treated as a new path.
+		updated, _ = update(updated, MotifMsg{Data: MotifData{
+			Path: "/root/a.txt", IsDir: false,
+		}})
+		Expect(updated.files).To(Equal(2))
+	})
+
+	It("returns no cmd", func() {
+		m := baseModel(1)
+		_, cmd := update(m, CompleteMsg{})
+		Expect(cmd).To(BeNil())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Model.Update - unknown message
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Model.Update - unknown message", func() {
+	It("returns the model unchanged with nil cmd", func() {
+		m := baseModel(1)
+		_, cmd := update(m, "some-unknown-msg")
+		Expect(cmd).To(BeNil())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// View
+// ---------------------------------------------------------------------------
+
+var _ = Describe("View", func() {
+	It("renders all lanes with separators", func() {
+		m := New(
+			WithLanes([]Lane{baseLane(), baseLane(), baseLane()}),
+			WithTheme(testTheme()),
+			WithWidth(80),
+		)
+		v := m.View()
+		// Three lanes means three `├──` separators.
+		Expect(v.Content).To(ContainSubstring("├"))
+		// Worker emoji appears at least three times (once
+		// per lane).
+		Expect(countOccurrences(v.Content, "🔍")).To(BeNumerically(">=", 3))
+	})
+
+	It("respects WidthMsg", func() {
+		m := New(
+			WithLanes([]Lane{baseLane()}),
+			WithTheme(testTheme()),
+		)
+		m, _ = update(m, WidthMsg{Width: 100})
+		v := m.View()
+		Expect(v.Content).NotTo(BeEmpty())
+	})
+
+	It("returns an empty string when there are no lanes", func() {
+		m := New(WithTheme(testTheme()), WithWidth(80))
+		Expect(m.View().Content).To(BeEmpty())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Lane.WindowSize
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Lane.WindowSize", func() {
+	It("returns the command output length when present", func() {
+		l := Lane{CommandOutput: "hello"}
+		Expect(l.WindowSize()).To(Equal(5))
+	})
+
+	It("returns 6 for action animations on files", func() {
+		l := Lane{ActionName: "encode", IsDir: false}
+		Expect(l.WindowSize()).To(Equal(6))
+	})
+
+	It("returns 4 for the default case", func() {
+		l := Lane{}
+		Expect(l.WindowSize()).To(Equal(4))
+	})
+
+	It("returns 4 for dir with action name (action animation is file-only)", func() {
+		l := Lane{ActionName: "encode", IsDir: true}
+		Expect(l.WindowSize()).To(Equal(4))
+	})
+})
+
+// Reference imports that may become unused after future refactors.
+var _ = testing.Short

--- a/src/prism/widgets/track/update.go
+++ b/src/prism/widgets/track/update.go
@@ -1,0 +1,137 @@
+package track
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/snivilised/jaywalk/src/prism/effects"
+)
+
+// Update handles widget-owned messages. The widget does not own a
+// ticker: TickMsg is supplied by the highway root on every global
+// tick. MotifMsg applies data to the current lane, increments the
+// deduped files/dirs counters and rotates the lane index.
+// CompleteMsg is a flush signal that clears the counted map.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case WidthMsg:
+		m.width = msg.Width
+		return m, nil
+
+	case TickMsg:
+		// Advance each lane's frame counter independently.
+		// Lanes with a skip factor > 0 (set via IntervalMs
+		// override) only advance their tick every N global
+		// ticks, producing a visibly slower animation. Lanes
+		// with skip factor 0 advance every tick (full speed).
+		for i := range m.lanes {
+			if m.skip != nil && i < len(m.skip) && m.skip[i] > 0 {
+				m.lanes[i].skipCounter++
+				if m.lanes[i].skipCounter >= m.skip[i] {
+					m.lanes[i].skipCounter = 0
+					m.lanes[i].tick++
+				}
+			} else {
+				m.lanes[i].tick++
+			}
+
+			// Advance gradient state for lanes with configured
+			// gradients. The GradientState.Offset tracks the
+			// current position in the gradient array;
+			// ApplyGradient uses this offset to interpolate
+			// characters from Hi to Lo. The view reads
+			// GradientState to colour the frame.
+			if m.lanes[i].HighlightGradient != nil {
+				windowSize := m.lanes[i].WindowSize()
+				if windowSize <= 0 {
+					windowSize = 4
+				}
+				m.lanes[i].GradientState.Update(windowSize)
+			}
+
+			if m.lanes[i].PeriscopeGradient != nil {
+				windowSize := m.lanes[i].WindowSize()
+				if windowSize <= 0 {
+					windowSize = 4
+				}
+				m.lanes[i].PeriscopeGradientState.Update(windowSize)
+			}
+		}
+		return m, nil
+
+	case MotifMsg:
+		return m.applyMotifData(msg), nil
+
+	case CensusMsg:
+		if msg.MaxDepth > m.maxDepth {
+			m.maxDepth = msg.MaxDepth
+		}
+		return m, nil
+
+	case CompleteMsg:
+		// Flush signal. Clear the dedup map so any further
+		// MotifMsg is a no-op dedup-wise. (We intentionally do
+		// NOT add a guard that drops motifs received after
+		// CompleteMsg, to preserve the pre-refactor behaviour
+		// where late motifs were still applied to the lane.)
+		m.counted = make(map[string]bool)
+		return m, nil
+
+	default:
+		return m, nil
+	}
+}
+
+// applyMotifData is the per-MotifMsg body. Extracted from the
+// former highway.Model.applyMotifData so the Update switch arm
+// stays readable. The dedup is on the path: a second motif with
+// the same path increments neither files nor dirs but still
+// applies its data to the current lane and rotates the index.
+func (m Model) applyMotifData(msg MotifMsg) Model {
+	data := msg.Data
+	if m.counted == nil {
+		m.counted = make(map[string]bool)
+	}
+	if !m.counted[data.Path] {
+		m.counted[data.Path] = true
+		if data.IsDir {
+			m.dirs++
+		} else {
+			m.files++
+		}
+	}
+	if len(m.lanes) > 0 {
+		idx := m.currentLaneIdx
+		m.lanes[idx].JobEmoji = data.JobEmoji
+		m.lanes[idx].Path = data.Path
+		m.lanes[idx].Name = data.Name
+		m.lanes[idx].IsDir = data.IsDir
+		m.lanes[idx].Depth = data.Depth
+		m.lanes[idx].ActionName = data.ActionName
+		m.lanes[idx].PipelineName = data.PipelineName
+		m.lanes[idx].CommandOutput = data.CommandOutput
+		m.lanes[idx].ExecutionString = data.ExecutionString
+		m.lanes[idx].DryRun = data.DryRun
+		m.lanes[idx].Err = data.Err
+
+		// Copy gradient from message to lane if provided. The
+		// gradient is a ResolvedGradient{Steps, Hi, Lo} from
+		// the theme palette. It holds colour endpoint info;
+		// the view applies it via ApplyGradient.
+		if data.Gradient != nil {
+			m.lanes[idx].HighlightGradient = data.Gradient
+			if m.lanes[idx].GradientState == nil {
+				m.lanes[idx].GradientState = effects.NewGradientState()
+			}
+			m.lanes[idx].GradientState.TotalSteps = data.Gradient.Steps
+		}
+		if data.PeriscopeGradient != nil {
+			m.lanes[idx].PeriscopeGradient = data.PeriscopeGradient
+			if m.lanes[idx].PeriscopeGradientState == nil {
+				m.lanes[idx].PeriscopeGradientState = effects.NewGradientState()
+			}
+			m.lanes[idx].PeriscopeGradientState.TotalSteps = data.PeriscopeGradient.Steps
+		}
+		m.currentLaneIdx = (m.currentLaneIdx + 1) % len(m.lanes)
+	}
+	return m
+}

--- a/src/prism/widgets/track/view.go
+++ b/src/prism/widgets/track/view.go
@@ -1,8 +1,10 @@
-package highway
+package track
 
 import (
 	"fmt"
 	"strings"
+
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/snivilised/jaywalk/src/prism/layout"
 	"github.com/snivilised/jaywalk/src/prism/widgets/action"
@@ -12,80 +14,87 @@ import (
 	"github.com/snivilised/jaywalk/src/prism/widgets/periscope"
 )
 
-// renderLanes renders each highway lane with animation frames and event data.
-// Rendering order per lane (left to right inside one frame):
-// | 🤖  ◼◻◻◻◻◻◻◻◻◻  🍎  📁  • via boo  braillewave       <Path>  ⠁⠂⠄⡀        [👾 sleep 1.0s] |
+// View renders every lane in the track, one row per lane with a
+// `├──┤` separator between rows. The full multi-lane string is
+// returned as a single tea.View so the highway root can embed it
+// in its bordered layout.
 //
-//  1. Left border segment │
-//  2. Worker emoji indicator (changes per job arrival)
-//  3. Periscope bar (indentation depth or animated fill pattern)
-//  4. Job emoji indicator (changes per job arrival)
-//  5. Node icon (file/folder tree icon, if path is present)
-//  6. Action info (error message / action name / pipeline name)
-//  7. Spinner column (fixed width label for spinner type: "default", "bounce", etc.)
-//  8. Styled path or label (files get DirStyle/FileStyle, empty lanes get MutedStyle)
-//  9. Animation frame (frame content from FrameFunc in quotes)
+// Rendering order per lane (left to right inside one frame):
+//
+//		🤖  ◼◻◻◻◻◻◻◻◻◻  🍎  📁  • via boo  braillewave       <Path>  ⠁⠂⠄⡀        [👾 sleep 1.0s]
+//
+//	 1. Left border segment │
+//	 2. Worker emoji indicator (changes per job arrival)
+//	 3. Periscope bar (indentation depth or animated fill pattern)
+//	 4. Job emoji indicator (changes per job arrival)
+//	 5. Node icon (file/folder tree icon, if path is present)
+//	 6. Action info (error message / action name / pipeline name)
+//	 7. Spinner column (fixed width label for spinner type: "default", "bounce", etc.)
+//	 8. Styled path or label (files get DirStyle/FileStyle, empty lanes get MutedStyle)
+//	 9. Animation frame (frame content from FrameFunc in quotes)
 //
 // 10. Landing strip
-//
 // 11. Right border segment │
+func (m Model) View() tea.View {
+	var b strings.Builder
+	m.renderLanes(&b)
+	return tea.NewView(b.String())
+}
+
+// renderLanes writes the lane rows to b. The body is the former
+// highway.Model.renderLanes moved verbatim, with the only edit
+// being the theme read replaced by m.styles.
 func (m Model) renderLanes(b *strings.Builder) {
 	laneBarWidth := LaneBarWidth
 
 	periscopeStyles := periscope.Styles{
-		Filled: m.theme.BarFilledStyle,
-		Empty:  m.theme.BarEmptyStyle,
+		Filled: m.styles.BarFilledStyle,
+		Empty:  m.styles.BarEmptyStyle,
 	}
 	actionStyles := action.Styles{
-		ErrorStyle:    m.theme.ErrorStyle,
-		ActionStyle:   m.theme.ActionStyle,
-		PipelineStyle: m.theme.PipelineStyle,
+		ErrorStyle:    m.styles.ErrorStyle,
+		ActionStyle:   m.styles.ActionStyle,
+		PipelineStyle: m.styles.PipelineStyle,
 	}
 	nodePathStyles := node.Styles{
-		DirStyle:   m.theme.DirStyle,
-		FileStyle:  m.theme.FileStyle,
-		MutedStyle: m.theme.MutedStyle,
-		TreeIcons:  m.theme.TreeIcons,
+		DirStyle:   m.styles.DirStyle,
+		FileStyle:  m.styles.FileStyle,
+		MutedStyle: m.styles.MutedStyle,
+		TreeIcons:  m.styles.TreeIcons,
 	}
 	activityStyles := activity.Styles{
-		FrameStyle: m.theme.FrameStyle,
+		FrameStyle: m.styles.FrameStyle,
 	}
 	landingStripStyles := landing.Styles{
-		BranchStyle:       m.theme.BranchStyle,
-		LandingStripStyle: m.theme.LandingStripStyle,
+		BranchStyle:       m.styles.BranchStyle,
+		LandingStripStyle: m.styles.LandingStripStyle,
 	}
 
-	borderStyle := m.theme.BorderStyle
-	mutedStyle := m.theme.MutedStyle
+	borderStyle := m.styles.BorderStyle
+	mutedStyle := m.styles.MutedStyle
 
 	for i, lane := range m.lanes {
 		emojiPart := lane.Emoji
 
-		// Periscope bar (depth indicator)
 		periscopeContent := m.renderPeriscopeBar(lane, i, laneBarWidth, periscopeStyles)
 
-		// Action info (error / action name / pipeline name)
 		actionContent := action.Render(action.Config{
 			Error:        lane.Err,
 			ActionName:   lane.ActionName,
 			PipelineName: lane.PipelineName,
 		}, actionStyles)
 
-		// Spinner name column (fixed width)
 		spinnerNameCol := fmt.Sprintf("%-*s", SpinnerNameWidth, lane.SpinnerName)
 		spinnerNameCol = mutedStyle.Render(spinnerNameCol)
 
-		// Animation frame with optional gradient
 		frame := m.renderActivityFrame(lane, activityStyles)
 
-		// Landing strip (execution info)
 		landingStripContent := landing.Render(landing.Config{
 			CommandOutput:   lane.CommandOutput,
 			ExecutionString: lane.ExecutionString,
 			DryRun:          lane.DryRun,
 		}, landingStripStyles)
 
-		// Build the row layout declaratively
 		row := layout.NewRow(m.width-4).
 			Caps(borderStyle.Render("│ "), borderStyle.Render(" │"))
 		row.
@@ -99,11 +108,10 @@ func (m Model) renderLanes(b *strings.Builder) {
 		}
 		row.
 			Fixed(SpinnerNameWidth, spinnerNameCol).
-			Flex(true).Gap(2). // path: flex with gap(2) before
+			Flex(true).Gap(2).
 			Content(frame).Gap(1).
 			RightContent(landingStripContent)
 
-		// Render the path content - returns complete formatted string with icon
 		pathContent := node.Render(node.Config{
 			Path:     lane.Path,
 			IsDir:    lane.IsDir,
@@ -122,6 +130,8 @@ func (m Model) renderLanes(b *strings.Builder) {
 	}
 }
 
+// renderPeriscopeBar returns the periscope bar content for the
+// given lane. Moved verbatim from highway.Model.renderPeriscopeBar.
 func (m Model) renderPeriscopeBar(lane Lane, idx int, width int, styles periscope.Styles) string {
 	if m.noRecurse {
 		return styles.Filled.Render("◼")
@@ -146,6 +156,9 @@ func (m Model) renderPeriscopeBar(lane Lane, idx int, width int, styles periscop
 	})
 }
 
+// renderActivityFrame returns the styled animation frame content
+// for the given lane. Moved verbatim from
+// highway.Model.renderActivityFrame.
 func (m Model) renderActivityFrame(lane Lane, styles activity.Styles) string {
 	var frameContent string
 	if lane.FrameFn != nil {
@@ -157,11 +170,8 @@ func (m Model) renderActivityFrame(lane Lane, styles activity.Styles) string {
 
 	return activity.Render(activity.Config{
 		Content: frameContent,
-	},
-		styles,
-		activity.Effect{
-			Gradient: lane.HighlightGradient,
-			State:    lane.GradientState,
-		},
-	)
+	}, styles, activity.Effect{
+		Gradient: lane.HighlightGradient,
+		State:    lane.GradientState,
+	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal lane animation and rendering logic into a dedicated track widget module.

* **Tests**
  * Updated unit tests to reflect the refactored component architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->