### PR TITLE
ref(prism): share common code netween views (#616)

### DIFF
--- a/src/prism/views/highway/view.go
+++ b/src/prism/views/highway/view.go
@@ -6,7 +6,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/snivilised/jaywalk/src/prism/contract"
-	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
+	"github.com/snivilised/jaywalk/src/prism/views/shared"
 	"github.com/snivilised/jaywalk/src/prism/widgets/legend"
 )
 
@@ -17,7 +17,7 @@ func (m Model) View() tea.View {
 	// top border. This is independent of the flags row position
 	// because the flags row lives INSIDE the border.
 	if m.bannerInfo.Position == contract.PositionTop {
-		m.writeBanner(&b)
+		shared.WriteBanner(&b, m.bannerInfo, m.Width)
 	}
 
 	m.renderHeader(&b)
@@ -32,7 +32,8 @@ func (m Model) View() tea.View {
 	// own styling and rendering.
 	b.WriteString(m.track.View().Content)
 
-	if (m.FlagsRowPosition == contract.PositionBottom || m.FlagsRowPosition == "") && m.hasFlags() {
+	if (m.FlagsRowPosition == contract.PositionBottom || m.FlagsRowPosition == "") &&
+		m.hasFlags() {
 		m.WriteSeparator(&b)
 		m.writeLegend(&b)
 		m.WriteSeparator(&b)
@@ -45,7 +46,7 @@ func (m Model) View() tea.View {
 	// keep the banner from overwriting the border.
 	if m.bannerInfo.Position == contract.PositionBottom {
 		b.WriteByte('\n')
-		m.writeBanner(&b)
+		shared.WriteBanner(&b, m.bannerInfo, m.Width)
 	}
 
 	v := tea.NewView(b.String())
@@ -53,75 +54,32 @@ func (m Model) View() tea.View {
 	return v
 }
 
-// hasFlags reports whether the legend section will render any
-// content. Used to skip emitting the surrounding separator borders
-// when there are no active flags, so the layout collapses cleanly.
+// hasFlags reports whether the legend section will render any content.
+// Used to skip emitting the surrounding separator borders when there
+// are no active flags, so the layout collapses cleanly.
 func (m Model) hasFlags() bool {
-	lm := legend.NewModel(
-		legend.WithInfo(legend.Info{
-			Position: m.FlagsRowPosition,
-			Header:   m.Header,
-		}),
-		legend.WithWidth(m.Width),
-		legend.WithStyles(legend.Styles{
-			LabelStyle:  m.Theme.SummaryLabelStyle.Width(0),
-			ValueStyle:  m.Theme.SummaryValueStyle,
-			BorderStyle: m.Theme.BorderStyle,
-		}),
-	)
-	return lm.Height() > 0
+	return shared.LegendHeight(m.legendParams()) > 0
 }
 
-// writeBanner constructs a banner.Model on the fly using the
-// frozen-per-session bannerInfo plus the current terminal width,
-// calls View(), and writes the result to b. The transient model
-// pattern matches the user's guidance: maximum reuse of the
-// existing Render function, no long-lived banner child on the
-// highway root.
-//
-// The view only calls this when bannerInfo.Position is top or
-// bottom; an unknown position value means "no banner" (see the
-// Risk note in make-banner-its-own-child-widget.implementation-plan.issue-606.md).
-// Disabled is also checked so the highway does not emit ANSI codes
-// when the gradient binding is absent.
-func (m Model) writeBanner(b *strings.Builder) {
-	bm := banner.NewModel(
-		banner.WithInfo(m.bannerInfo),
-		banner.WithWidth(m.Width),
-	)
-	if bm.Disabled() {
-		return
-	}
-	if out := bm.View(); out != "" {
-		b.WriteString(out)
-	}
-}
-
-// writeLegend constructs a legend.Model on the fly using the
-// frozen-per-session headerInfo plus the current terminal width
-// and the theme's flags-row styles, calls View(), and writes the
-// result to b. The transient model pattern mirrors writeBanner:
-// no long-lived legend child on the highway root.
-//
-// The view only calls this when FlagsRowPosition is top or bottom;
-// an unknown / empty value (which the model has already coerced
-// to bottom) means "render the row at the bottom". The legend
-// widget itself short-circuits to "" when no flag is active, so
-// callers do not need to guard.
+// writeLegend renders the flags/legend row into b using the shared
+// chrome utility. The row is a no-op when no flag is active.
 func (m Model) writeLegend(b *strings.Builder) {
-	lm := legend.NewModel(
-		legend.WithInfo(legend.Info{
+	shared.WriteLegend(b, m.legendParams())
+}
+
+// legendParams returns the LegendParams for the current model state.
+// Centralised here so hasFlags and writeLegend stay consistent.
+func (m Model) legendParams() shared.LegendParams {
+	return shared.LegendParams{
+		Info: legend.Info{
 			Position: m.FlagsRowPosition,
 			Header:   m.Header,
-		}),
-		legend.WithWidth(m.Width),
-		legend.WithStyles(legend.Styles{
+		},
+		Width: m.Width,
+		Styles: legend.Styles{
 			LabelStyle:  m.Theme.SummaryLabelStyle.Width(0),
 			ValueStyle:  m.Theme.SummaryValueStyle,
 			BorderStyle: m.Theme.BorderStyle,
-		}),
-	)
-	if out := lm.View(); out != "" {
-		b.WriteString(out)
+		},
 	}
 }

--- a/src/prism/views/porthole/model.go
+++ b/src/prism/views/porthole/model.go
@@ -11,7 +11,6 @@ import (
 	"github.com/snivilised/jaywalk/src/prism/effects"
 	"github.com/snivilised/jaywalk/src/prism/views/linear"
 	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
-	"github.com/snivilised/jaywalk/src/prism/widgets/legend"
 	"github.com/snivilised/jaywalk/src/prism/widgets/scrollbar"
 	"github.com/snivilised/jaywalk/src/prism/widgets/status"
 )
@@ -394,62 +393,6 @@ func (m *Model) rerender() {
 		}
 	}
 	m.contentBuf = newBuf
-}
-
-// legendHeight returns the number of terminal rows the legend will
-// occupy (entry lines only) given the current flags configuration.
-// Returns 0 when the legend is hidden or has no flags active so the
-// viewport can claim the full body height in that case. Surrounding
-// borders are the view's responsibility - use legendSectionHeight
-// for the total section size including the two framing separators.
-func (m Model) legendHeight() int {
-	lm := legend.NewModel(
-		legend.WithInfo(legend.Info{
-			Position: m.FlagsRowPosition,
-			Header:   m.Header,
-		}),
-		legend.WithWidth(m.Width),
-		legend.WithStyles(legend.Styles{
-			LabelStyle:  m.Theme.SummaryLabelStyle.Width(0),
-			ValueStyle:  m.Theme.SummaryValueStyle,
-			BorderStyle: m.Theme.BorderStyle,
-		}),
-	)
-	return lm.Height()
-}
-
-// legendSectionHeight returns the total number of rows the legend
-// section will occupy in the view: entry lines + 2 separator borders
-// (one above and one below the flags). Returns 0 when no flags are
-// active so callers can simply skip the section.
-func (m Model) legendSectionHeight() int {
-	h := m.legendHeight()
-	if h == 0 {
-		return 0
-	}
-	return h + 2
-}
-
-// writeLegend renders the flags/legend row (cascade, filter, sampler)
-// into the builder. It mirrors the highway's writeLegend pattern:
-// construct a transient legend.Model on the fly, render, and write.
-// The row is a no-op when no flag is active.
-func (m Model) writeLegend(b *strings.Builder) {
-	lm := legend.NewModel(
-		legend.WithInfo(legend.Info{
-			Position: m.FlagsRowPosition,
-			Header:   m.Header,
-		}),
-		legend.WithWidth(m.Width),
-		legend.WithStyles(legend.Styles{
-			LabelStyle:  m.Theme.SummaryLabelStyle.Width(0),
-			ValueStyle:  m.Theme.SummaryValueStyle,
-			BorderStyle: m.Theme.BorderStyle,
-		}),
-	)
-	if out := lm.View(); out != "" {
-		b.WriteString(out)
-	}
 }
 
 // truncateStyled truncates a lipgloss-styled string to maxVisible visible

--- a/src/prism/views/porthole/view.go
+++ b/src/prism/views/porthole/view.go
@@ -10,10 +10,11 @@ import (
 	"github.com/snivilised/jaywalk/src/prism/contract"
 	"github.com/snivilised/jaywalk/src/prism/layout"
 	"github.com/snivilised/jaywalk/src/prism/views/linear"
+	"github.com/snivilised/jaywalk/src/prism/views/shared"
 	"github.com/snivilised/jaywalk/src/prism/widgets/activity"
-	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
 	"github.com/snivilised/jaywalk/src/prism/widgets/border"
 	"github.com/snivilised/jaywalk/src/prism/widgets/intro"
+	"github.com/snivilised/jaywalk/src/prism/widgets/legend"
 	"github.com/snivilised/jaywalk/src/prism/widgets/pipeline"
 	"github.com/snivilised/jaywalk/src/prism/widgets/scrollbar"
 )
@@ -21,8 +22,11 @@ import (
 func (m *Model) View() tea.View {
 	var b strings.Builder
 
+	// Banner at top: rendered OUTSIDE the bordered region, above the
+	// top border. This is independent of the flags row position
+	// because the flags row lives INSIDE the border.
 	if m.bannerInfo.Position == contract.PositionTop {
-		m.writeBanner(&b)
+		shared.WriteBanner(&b, m.bannerInfo, m.Width)
 	}
 
 	m.renderHeader(&b)
@@ -54,22 +58,18 @@ func (m *Model) View() tea.View {
 		b.WriteString(m.Theme.MutedStyle.Render(" • press space to exit"))
 	}
 
+	// Banner at bottom: rendered OUTSIDE the bordered region, below
+	// the summary. The summary's last line is the bottom border
+	// (no trailing newline), so we emit a separator newline to
+	// keep the banner from overwriting the border.
+	if m.bannerInfo.Position == contract.PositionBottom {
+		b.WriteByte('\n')
+		shared.WriteBanner(&b, m.bannerInfo, m.Width)
+	}
+
 	v := tea.NewView(b.String())
 	v.AltScreen = true
 	return v
-}
-
-func (m Model) writeBanner(b *strings.Builder) {
-	bm := banner.NewModel(
-		banner.WithInfo(m.bannerInfo),
-		banner.WithWidth(m.Width),
-	)
-	if bm.Disabled() {
-		return
-	}
-	if out := bm.View(); out != "" {
-		b.WriteString(out)
-	}
 }
 
 func (m Model) renderHeader(b *strings.Builder) {
@@ -255,4 +255,42 @@ func (m Model) renderActivity() string {
 		Gradient: m.activityGradient,
 		State:    m.gradientState,
 	})
+}
+
+// writeLegend renders the flags/legend row into b using the shared
+// chrome utility. The row is a no-op when no flag is active.
+func (m Model) writeLegend(b *strings.Builder) {
+	shared.WriteLegend(b, m.legendParams())
+}
+
+// legendHeight returns the number of terminal rows the legend will
+// occupy (entry lines only). Returns 0 when no flags are active so
+// the viewport can claim the full available height.
+func (m Model) legendHeight() int {
+	return shared.LegendHeight(m.legendParams())
+}
+
+// legendSectionHeight returns the total number of rows the legend
+// section will occupy in the view: entry lines plus the two separator
+// borders that frame it (one above, one below). Returns 0 when no
+// flags are active so callers can skip the section entirely.
+func (m Model) legendSectionHeight() int {
+	return shared.LegendSectionHeight(m.legendParams())
+}
+
+// legendParams returns the LegendParams for the current model state.
+// Centralised here so all legend-related methods stay consistent.
+func (m Model) legendParams() shared.LegendParams {
+	return shared.LegendParams{
+		Info: legend.Info{
+			Position: m.FlagsRowPosition,
+			Header:   m.Header,
+		},
+		Width: m.Width,
+		Styles: legend.Styles{
+			LabelStyle:  m.Theme.SummaryLabelStyle.Width(0),
+			ValueStyle:  m.Theme.SummaryValueStyle,
+			BorderStyle: m.Theme.BorderStyle,
+		},
+	}
 }

--- a/src/prism/views/shared/chrome.go
+++ b/src/prism/views/shared/chrome.go
@@ -1,0 +1,75 @@
+package shared
+
+import (
+	"strings"
+
+	"github.com/snivilised/jaywalk/src/prism/widgets/banner"
+	"github.com/snivilised/jaywalk/src/prism/widgets/legend"
+)
+
+// WriteBanner constructs a transient banner.Model from info and width,
+// checks whether it is disabled, and writes its rendered output to b.
+// The caller is responsible for emitting any separator newline that
+// must precede the banner (e.g. when rendering at the bottom position).
+// When the banner is disabled or produces no output, b is unchanged.
+func WriteBanner(b *strings.Builder, info banner.Info, width int) {
+	bm := banner.NewModel(
+		banner.WithInfo(info),
+		banner.WithWidth(width),
+	)
+	if bm.Disabled() {
+		return
+	}
+	if out := bm.View(); out != "" {
+		b.WriteString(out)
+	}
+}
+
+// WriteLegend constructs a transient legend.Model from the supplied
+// parameters and writes its rendered output to b. When no flags are
+// active the legend produces no output and b is unchanged.
+func WriteLegend(b *strings.Builder, params LegendParams) {
+	lm := newLegendModel(params)
+	if out := lm.View(); out != "" {
+		b.WriteString(out)
+	}
+}
+
+// LegendHeight returns the number of terminal rows the legend will
+// occupy (entry lines only). Returns 0 when no flags are active so
+// the caller can skip the section entirely.
+func LegendHeight(params LegendParams) int {
+	return newLegendModel(params).Height()
+}
+
+// LegendSectionHeight returns the total number of rows the legend
+// section occupies: entry lines plus the two separator borders that
+// frame it (one above, one below). Returns 0 when no flags are active
+// so callers can skip the section and claim the full available height.
+func LegendSectionHeight(params LegendParams) int {
+	h := LegendHeight(params)
+	if h == 0 {
+		return 0
+	}
+	return h + 2
+}
+
+// LegendParams groups the inputs required to construct a transient
+// legend.Model. Both the highway and porthole views populate this on
+// every render; the legend widget itself is stateless.
+type LegendParams struct {
+	Info   legend.Info
+	Width  int
+	Styles legend.Styles
+}
+
+// newLegendModel is the single construction site for the transient
+// legend.Model. All exported functions in this file delegate here so
+// the construction options stay consistent.
+func newLegendModel(p LegendParams) legend.Model {
+	return legend.NewModel(
+		legend.WithInfo(p.Info),
+		legend.WithWidth(p.Width),
+		legend.WithStyles(p.Styles),
+	)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bottom banner positioning in porthole views.

* **Refactor**
  * Consolidated banner and legend rendering logic into shared utilities for consistent rendering across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->