### PR TITLE
fix(agenor): ensure base part of glob ex filter is effective (#637)

### DIFF
--- a/src/agenor/internal/filtering/filter-glob-ex_test.go
+++ b/src/agenor/internal/filtering/filter-glob-ex_test.go
@@ -388,12 +388,12 @@ var _ = Describe("filtering", Ordered, func() {
 				Relative:     "rock/PROGRESSIVE-ROCK/Marillion",
 				Subscription: enums.SubscribeFiles,
 				ExpectedNoOf: lab.Quantities{
-					Files: 8,
+					Files: 4,
 				},
 				Mandatory:  []string{"cover-clutching-at-straws.jpg"},
 				Prohibited: []string{"01 - Assassing.flac"},
 			},
-			Description:     "directory starts with c, any extension",
+			Description:     "filename starts with c, any extension",
 			Pattern:         "c*|.*",
 			IfNotApplicable: enums.TriStateBoolFalse,
 		}),
@@ -412,7 +412,7 @@ var _ = Describe("filtering", Ordered, func() {
 				},
 				Mandatory: []string{"cover-clutching-at-straws.jpg"},
 			},
-			Description:     "directory starts with c, any extension",
+			Description:     "filename starts with c, any extension",
 			Pattern:         "c*|.*",
 			IfNotApplicable: enums.TriStateBoolTrue, // see GlobEx.IsMatch description
 		}),
@@ -470,7 +470,7 @@ var _ = Describe("filtering", Ordered, func() {
 				Prohibited: []string{"01 - Hotel Hobbies.flac"},
 			},
 			Description:     "files starting with 0, except 01 items and flac suffix",
-			Pattern:         "*/c*|*.flac",
+			Pattern:         "0*/01*|*.flac",
 			IfNotApplicable: enums.TriStateBoolFalse,
 		}),
 	)

--- a/src/agenor/internal/filtering/glob-ex.go
+++ b/src/agenor/internal/filtering/glob-ex.go
@@ -55,8 +55,8 @@ func createGlobExFilter(def *core.FilterDef,
 
 // GlobEx is a filter that matches files based on a glob pattern. An extended
 // glob pattern allows for multiple patterns to be defined that is applied to
-// the filename itself as well as a pattern that is applied to the file's parent
-// directory.
+// the filename itself: a base glob that must match the filename, and a set of
+// suffixes that must also match the filename.
 type GlobEx struct {
 	Base
 	spec *globSpec
@@ -66,27 +66,25 @@ type GlobEx struct {
 // It returns true if the filter matches the node, false otherwise.
 func (f *GlobEx) IsApplicable(node *core.Node) bool {
 	if f.Base.IsApplicable(node) {
-		return f.isDirectoryMatch(node)
+		return f.isBaseMatch(node)
 	}
 
 	return false
 }
 
-func (f *GlobEx) isDirectoryMatch(node *core.Node) bool {
-	if node.Parent != nil {
-		name := strings.ToLower(node.Parent.Extension.Name)
+func (f *GlobEx) isBaseMatch(node *core.Node) bool {
+	name := strings.ToLower(node.Extension.Name)
 
-		if result, _ := filepath.Match(
-			f.spec.directoryGlob, name,
-		); !result {
-			return false
-		}
+	if result, _ := filepath.Match(
+		f.spec.directoryGlob, name,
+	); !result {
+		return false
+	}
 
-		if excluded, _ := filepath.Match(
-			f.spec.directoryExclusion, name,
-		); excluded {
-			return false
-		}
+	if excluded, _ := filepath.Match(
+		f.spec.directoryExclusion, name,
+	); excluded {
+		return false
 	}
 
 	return true

--- a/src/app/controller/options.go
+++ b/src/app/controller/options.go
@@ -78,11 +78,13 @@ func TranslateFilterIntent(intent FilterIntent) (pref.Option, bool) {
 		case intent.FilesExGlob != "":
 			fileDef.Type = enums.FilterTypeGlobEx
 			fileDef.Pattern = intent.FilesExGlob
-			fileDef.Description = fmt.Sprintf("files-glob:%s", intent.FilesExGlob)
+							fileDef.Description = fmt.Sprintf("files-glob:%s", intent.FilesExGlob)
+				fileDef.IfNotApplicable = enums.TriStateBoolFalse
 		case intent.FilesRegEx != "":
 			fileDef.Type = enums.FilterTypeRegex
 			fileDef.Pattern = intent.FilesRegEx
-			fileDef.Description = fmt.Sprintf("files-regex:%s", intent.FilesRegEx)
+							fileDef.Description = fmt.Sprintf("files-regex:%s", intent.FilesRegEx)
+				fileDef.IfNotApplicable = enums.TriStateBoolFalse
 		}
 	} else {
 		fileDef = core.BenignNodeFilterDef // allow all files when no file filter specified
@@ -97,11 +99,13 @@ func TranslateFilterIntent(intent FilterIntent) (pref.Option, bool) {
 		case intent.DirectoriesGlob != "":
 			dirDef.Type = enums.FilterTypeGlob
 			dirDef.Pattern = intent.DirectoriesGlob
-			dirDef.Description = fmt.Sprintf("dirs-glob:%s", intent.DirectoriesGlob)
+							dirDef.Description = fmt.Sprintf("dirs-glob:%s", intent.DirectoriesGlob)
+				dirDef.IfNotApplicable = enums.TriStateBoolFalse
 		case intent.DirectoriesRegEx != "":
 			dirDef.Type = enums.FilterTypeRegex
 			dirDef.Pattern = intent.DirectoriesRegEx
-			dirDef.Description = fmt.Sprintf("dirs-regex:%s", intent.DirectoriesRegEx)
+							dirDef.Description = fmt.Sprintf("dirs-regex:%s", intent.DirectoriesRegEx)
+				dirDef.IfNotApplicable = enums.TriStateBoolFalse
 		}
 	} else {
 		dirDef = core.BenignNodeFilterDef // allow all directories when no dir filter specified


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file filtering logic to match against file extensions instead of parent directory extensions
  * Updated glob pattern filtering to apply to filenames rather than directory names
  * Adjusted filter applicability settings for improved filtering accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->