### PR TITLE
fix(prism): ensure highway finishes on 100% progress (#643)

### DIFF
--- a/src/app/controller/coordinator.go
+++ b/src/app/controller/coordinator.go
@@ -333,6 +333,18 @@ func (c *Coordinator) execute(
 		traversal.Elapsed = result.Session().Elapsed()
 	}
 
+	// Wait for the worker pool to finish all pending jobs before signalling
+	// UI completion. Without this, CompleteMsg arrives at the UI before all
+	// async MotifMsgs have been dispatched, causing the "✔ complete" message
+	// to appear while workers are still executing.
+	if c.poolExec != nil {
+		c.poolExec.closeAll()
+		select {
+		case <-c.poolExec.done:
+		case <-ctx.Done():
+		}
+	}
+
 	req.UI.OnComplete(traversal)
 
 	return err
@@ -402,7 +414,6 @@ func (c *Coordinator) useShellPoolExec(
 		c.poolExec = nil
 		c.workerStateTracker = nil
 		c.exec = previousExec
-		executor.closeAll()
 	}, nil
 }
 

--- a/src/prism/views/highway/model.go
+++ b/src/prism/views/highway/model.go
@@ -61,11 +61,6 @@ type Model struct {
 	// translates highway messages into status.* messages
 	// (see update.go's translation helpers).
 	status status.Model
-
-	totalTicks int64
-	realMode   bool
-	totalFiles uint
-	totalDirs  uint
 }
 
 // NewModel constructs a highway view Model. The lanes slice is
@@ -128,10 +123,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.Done {
 			return m, nil
 		}
-		if m.Start.IsZero() && !m.realMode {
+		if m.Start.IsZero() {
 			m.Start = core.Now()
 		}
-		m.totalTicks++
 		// Forward the tick to the track child. Track advances
 		// each lane's tick counter, applies the per-lane skip
 		// factor and advances gradient states.
@@ -156,15 +150,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if elapsedCmd != nil {
 				cmds = append(cmds, elapsedCmd)
 			}
-			if !m.realMode {
-				// Demo mode only: push a time-derived percent
-				// so the bar animates without real traversal
-				// data. In real mode the percent is driven by
-				// TotalMsg + IncDoneMsg (the done/total ratio).
-				// TODO(realMode-cleanup): once the demo-mode
-				// fake percent generation moves into
-				// status.Update (or track.Update), the root
-				// no longer needs to know about it.
+			if !m.status.HasTotal() {
+				// No total means no CensusMsg has been received
+				// (demo mode or pre-Census). Push a time-derived
+				// percent so the bar animates without real
+				// traversal data. Once CensusMsg arrives the
+				// percent is driven by TotalMsg + IncDoneMsg
+				// (the done/total ratio).
 				m.status, _ = m.dispatchStatus(status.PercentMsg{
 					Percent: int(elapsed.Seconds()) * 2 % 100,
 				})
@@ -174,7 +166,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case OvertureMsg:
 		m.Start = core.Now()
-		m.realMode = true
 		m.ApplyOverture(&msg.OvertureMsg)
 
 		// Initialise the banner from the OvertureMsg. The bannerInfo
@@ -192,8 +183,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case contract.CensusMsg:
-		m.totalFiles = msg.TotalFiles
-		m.totalDirs = msg.TotalDirs
 		if msg.MaxDepth > m.MaxDepth {
 			m.MaxDepth = msg.MaxDepth
 		}
@@ -225,6 +214,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case contract.MotifMsg:
+		if m.Done {
+			// Traversal already completed; forward the motif
+			// to the track child for lane rendering/data but
+			// do NOT update status progress. Without this
+			// guard a late MotifMsg arriving after CompleteMsg
+			// dispatches an IncDoneMsg which recomputes the
+			// percent from done/total and overwrites the 100%
+			// that DoneMsg set.
+			m.track, _ = m.dispatchTrack(msg)
+			return m, nil
+		}
 		// Track the pre-dispatch file/dir counts so we can
 		// detect whether the motif was new (i.e. the track
 		// child's dedup map saw the path for the first time).
@@ -279,10 +279,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Forward the final counts and elapsed to the status
 		// widget. The widget owns the percent calculation and
-		// the isDone flag from here on. The status DoneMsg
-		// handler only overwrites its errMsg when msg.Err is
-		// non-empty, so passing the root's potentially-empty
-		// errMsg is safe.
+		// the isDone flag from here on. The Done field must
+		// include both files AND dirs because the progress
+		// total was seeded with TotalFiles + TotalDirs, and
+		// recomputePercent derives percent from done/total.
 		cmds := make([]tea.Cmd, 0, 2)
 		m.status, _ = m.dispatchStatus(status.CountsMsg{
 			Files: msg.Files, Dirs: msg.Dirs, Errors: len(msg.Errs),
@@ -290,7 +290,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.status, _ = m.dispatchStatus(status.ElapsedMsg{Elapsed: msg.Elapsed})
 		var cmd tea.Cmd
 		m.status, cmd = m.dispatchStatus(status.DoneMsg{
-			Done: msg.Files, IsDone: true, Err: m.ErrMsg,
+			Done: msg.Files + msg.Dirs, IsDone: true, Err: m.ErrMsg,
 		})
 		if cmd != nil {
 			cmds = append(cmds, cmd)

--- a/src/prism/views/highway/model_test.go
+++ b/src/prism/views/highway/model_test.go
@@ -2,6 +2,7 @@ package highway
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"time"
 
@@ -240,17 +241,8 @@ var _ = Describe("Model.Update - tickMsg", func() {
 		Expect(cmd).To(BeNil())
 	})
 
-	It("does not start the timer in realMode when start is zero", func() {
+	It("starts the timer on first tick when start is zero", func() {
 		m := baseModel(1)
-		m.realMode = true
-		updated, cmd := update(m, tickMsg(core.Now()))
-		Expect(updated.Start.IsZero()).To(BeTrue())
-		_ = cmd
-	})
-
-	It("starts the timer in demo mode when start is zero", func() {
-		m := baseModel(1)
-		m.realMode = false
 		Expect(m.Start.IsZero()).To(BeTrue())
 
 		updated, cmd := update(m, tickMsg(core.Now()))
@@ -279,21 +271,19 @@ var _ = Describe("Model.Update - tickMsg", func() {
 		Expect(m.track.Tick(1)).To(Equal(1), "slow lane should advance every 10th tick")
 	})
 
-	It("pushes elapsed to the status widget in real mode on every tick", func() {
+	It("pushes elapsed to the status widget on every tick after OvertureMsg", func() {
 		// Regression: ElapsedMsg was previously only dispatched
-		// in demo mode, so in real mode the status row's elapsed
-		// segment stayed at 0 for the entire traversal and only
-		// jumped to the final value on CompleteMsg. The elapsed
-		// is real in both modes and must tick up.
+		// in demo mode, so after OvertureMsg the status row's
+		// elapsed segment stayed at 0 for the entire traversal
+		// and only jumped to the final value on CompleteMsg. The
+		// elapsed is real in both modes and must tick up.
 		m := baseModel(1)
-		// OvertureMsg sets realMode and m.Start = now.
 		m, _ = update(m, OvertureMsg{
 			OvertureMsg: contract.OvertureMsg{
 				Root:    "/root",
 				Caption: "files",
 			},
 		})
-		Expect(m.realMode).To(BeTrue())
 		Expect(m.Start.IsZero()).To(BeFalse())
 		Expect(m.status.Elapsed()).To(Equal(time.Duration(0)),
 			"no tick yet, status elapsed stays at 0")
@@ -312,15 +302,15 @@ var _ = Describe("Model.Update - tickMsg", func() {
 		}
 	})
 
-	It("pushes elapsed to the status widget in demo mode on every tick", func() {
-		// Demo mode has always pushed ElapsedMsg; this test
-		// documents the behaviour alongside the real-mode case
-		// above so a future refactor doesn't drop it.
+	It("pushes elapsed to the status widget on every tick before OvertureMsg", func() {
+		// Before OvertureMsg, the first tick sets m.Start
+		// and subsequent ticks push elapsed. This test
+		// documents the behaviour alongside the post-OvertureMsg
+		// case above so a future refactor doesn't drop it.
 		m := baseModel(1)
-		Expect(m.realMode).To(BeFalse())
 		Expect(m.status.Elapsed()).To(Equal(time.Duration(0)))
 
-		// First tick sets m.Start (demo mode), so subsequent
+		// First tick sets m.Start so subsequent
 		// ticks can produce a non-zero elapsed.
 		m, _ = update(m, tickMsg(core.Now()))
 		first := m.status.Elapsed()
@@ -331,24 +321,23 @@ var _ = Describe("Model.Update - tickMsg", func() {
 		Expect(second).To(BeNumerically(">=", first))
 	})
 
-	It("drives the percent in demo mode via PercentMsg (not done/total)", func() {
-		// Demo mode has no real traversal data, so the percent
-		// must come from the time-derived PercentMsg - not from
+	It("drives the percent via PercentMsg before CensusMsg arrives", func() {
+		// Before CensusMsg (no total), the percent must come
+		// from the time-derived PercentMsg - not from
 		// recomputePercent (which would stay at 0 without a
 		// TotalMsg). This test pins down that contract.
 		m := baseModel(1)
 		for range 5 {
 			m, _ = update(m, tickMsg(core.Now()))
 		}
-		// The demo formula is int(elapsed.Seconds())*2 % 100.
+		// The formula is int(elapsed.Seconds())*2 % 100.
 		// We don't pin the exact value (it's time-dependent)
 		// but we do assert that the percent state is non-zero
 		// OR zero (the formula can produce 0 if elapsed is
 		// exactly a multiple of 50 seconds). The key assertion
-		// is the view contains no "100 / 100" ratio, because
-		// demo mode has no TotalMsg.
+		// is hasTotal stays false because no CensusMsg was sent.
 		Expect(m.status.HasTotal()).To(BeFalse(),
-			"demo mode never sends TotalMsg, so hasTotal stays false")
+			"no CensusMsg ever sent, so hasTotal stays false")
 	})
 })
 
@@ -357,9 +346,8 @@ var _ = Describe("Model.Update - tickMsg", func() {
 // ---------------------------------------------------------------------------
 
 var _ = Describe("Model.Update - OvertureMsg", func() {
-	It("sets rootPath, realMode, start time and pipelineName", func() {
+	It("sets rootPath, start time and pipelineName from OvertureMsg", func() {
 		m := baseModel(1)
-		Expect(m.realMode).To(BeFalse())
 		Expect(m.Start.IsZero()).To(BeTrue())
 
 		updated, cmd := update(m, OvertureMsg{
@@ -374,7 +362,6 @@ var _ = Describe("Model.Update - OvertureMsg", func() {
 		Expect(cmd).To(BeNil())
 
 		Expect(updated.RootPath).To(Equal("/project/src"))
-		Expect(updated.realMode).To(BeTrue())
 		Expect(updated.Start.IsZero()).To(BeFalse())
 		Expect(updated.PipelineName).To(Equal("ci"))
 	})
@@ -385,14 +372,12 @@ var _ = Describe("Model.Update - OvertureMsg", func() {
 // ---------------------------------------------------------------------------
 
 var _ = Describe("Model.Update - CensusMsg", func() {
-	It("sets totalFiles and totalDirs", func() {
+	It("seeds the status widget total from both files and dirs", func() {
 		m := baseModel(1)
 		updated, _ := update(m, contract.CensusMsg{TotalFiles: 100, TotalDirs: 20})
 		// cmd is the status spring's first-frame cmd (non-nil)
 		// because CensusMsg seeds the total and re-targets the
 		// embedded progress bar to 0.
-		Expect(updated.totalFiles).To(Equal(uint(100)))
-		Expect(updated.totalDirs).To(Equal(uint(20)))
 		// Regression: the status widget's total must be the sum
 		// of files and dirs, because every MotifMsg (file OR
 		// dir) increments done by 1. Seeding total with only
@@ -649,29 +634,221 @@ var _ = Describe("Model.Update - CompleteMsg", func() {
 		Expect(updated.Errors).To(Equal(2))
 	})
 
-	It("shows 100% on completion regardless of totalFiles", func() {
-		// CompleteMsg always reports the final counts and
-		// IsDone=true, which the highway root translates to
-		// status.DoneMsg{IsDone:true}. The status widget sets
-		// percent=100 unconditionally on IsDone=true, even when
-		// Files (80) is less than totalFiles (100). This is the
-		// "bar fills at completion" semantic.
+	It("shows ✔ complete on CompleteMsg only when percent has reached 100%", func() {
+		// The progress bar tracks the natural done/total ratio;
+		// the "✔ complete" message renders only when BOTH isDone
+		// AND percent >= 100. When the preview overcounts
+		// (total=100 but only 85 items visited), the bar stays
+		// at 85% and "✔ complete" does NOT show because progress
+		// has not fully covered the preview estimate.
 		m := baseModel(1)
+		m, _ = update(m, tea.WindowSizeMsg{Width: 120})
 		// Seed the total via CensusMsg (preview estimate).
 		updated, _ := update(m, contract.CensusMsg{TotalFiles: 100})
+		// Drive done below total.
+		for i := range 85 {
+			updated, _ = update(updated, contract.MotifMsg{
+				Path: fmt.Sprintf("/r/f%d.txt", i), IsDir: false,
+			})
+		}
+		Expect(updated.status.Done()).To(Equal(85))
+		Expect(updated.status.Percent()).To(Equal(85))
 
 		updated, cmd := update(updated, contract.CompleteMsg{Files: 80, Dirs: 5})
-		// The status widget returns nil cmd for DoneMsg (no
-		// animation driver in this PR), so the tea.Batch
-		// collapses to nil.
 		_ = cmd
 
+		// Done = Files+Dirs = 85, ratio = 85/100 = 85%.
+		// The displayed file/dir counts use max(previous, msg) so
+		// the tracker's count (85 files from 85 file-MotifMsgs)
+		// is retained rather than overwritten by CompleteMsg's
+		// lower breakdown (80 files + 5 dirs).
 		Expect(updated.status.IsDone()).To(BeTrue())
-		Expect(updated.status.Percent()).To(Equal(100))
-		Expect(updated.status.Files()).To(Equal(80))
+		Expect(updated.status.Percent()).To(Equal(85),
+			"bar shows the natural done/total ratio (85/100)")
+		Expect(updated.status.Files()).To(Equal(85))
 		Expect(updated.status.Dirs()).To(Equal(5))
-		Expect(updated.status.View().Content).To(ContainSubstring("100%"))
-		Expect(updated.status.View().Content).To(ContainSubstring("✔ complete"))
+		Expect(updated.status.View().Content).To(ContainSubstring("85%"))
+		Expect(updated.status.View().Content).NotTo(ContainSubstring("✔"),
+			"complete message hidden when percent < 100")
+
+		// When done matches total, "✔ complete" shows on CompleteMsg.
+		m2 := baseModel(1)
+		m2, _ = update(m2, tea.WindowSizeMsg{Width: 120})
+		m2, _ = update(m2, contract.CensusMsg{TotalFiles: 10, TotalDirs: 0})
+		for i := range 10 {
+			m2, _ = update(m2, contract.MotifMsg{
+				Path: fmt.Sprintf("/r/f%d.txt", i), IsDir: false,
+			})
+		}
+		m2, _ = update(m2, contract.CompleteMsg{Files: 10, Dirs: 0})
+		Expect(m2.status.Percent()).To(Equal(100))
+		Expect(m2.status.View().Content).To(ContainSubstring("100%"))
+		Expect(m2.status.View().Content).To(ContainSubstring("✔ complete"))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Model.Update - Completion flow (progress reaches 100%)
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Model.Update - completion flow", func() {
+	It("climbs to 100% through MotifMsg increments and stays at 100% on CompleteMsg", func() {
+		m := baseModel(1)
+		m, _ = update(m, tea.WindowSizeMsg{Width: 120})
+
+		// Seed total: 5 files + 3 dirs = 8 items.
+		m, _ = update(m, contract.CensusMsg{TotalFiles: 5, TotalDirs: 3})
+		Expect(m.status.Total()).To(Equal(8))
+		Expect(m.status.Percent()).To(Equal(0))
+
+		// Dispatch all 8 items. After each, the percent climbs.
+		items := []struct {
+			path  string
+			isDir bool
+			pct   int
+		}{
+			{"/r/f1.txt", false, 12}, // 1/8 = 12.5 → 12
+			{"/r/f2.txt", false, 25}, // 2/8 = 25
+			{"/r/d1", true, 37},      // 3/8 = 37.5 → 37
+			{"/r/f3.txt", false, 50}, // 4/8 = 50
+			{"/r/d2", true, 62},      // 5/8 = 62.5 → 62
+			{"/r/f4.txt", false, 75}, // 6/8 = 75
+			{"/r/f5.txt", false, 87}, // 7/8 = 87.5 → 87
+			{"/r/d3", true, 100},     // 8/8 = 100
+		}
+		for _, it := range items {
+			m, _ = update(m, contract.MotifMsg{
+				Path: it.path, IsDir: it.isDir,
+			})
+			Expect(m.status.Percent()).To(Equal(it.pct),
+				"percent after %q should be %d", it.path, it.pct)
+		}
+		Expect(m.status.Done()).To(Equal(8))
+		Expect(m.Done).To(BeFalse(), "progress is done but model.Done is still false")
+
+		// CompleteMsg finalises the traversal and keeps 100%.
+		m, cmd := update(m, contract.CompleteMsg{
+			Files: 5, Dirs: 3, Elapsed: 2 * time.Second,
+		})
+		_ = cmd
+		Expect(m.Done).To(BeTrue())
+		Expect(m.status.IsDone()).To(BeTrue())
+		Expect(m.status.Percent()).To(Equal(100))
+		Expect(m.status.View().Content).To(ContainSubstring("100%"))
+		Expect(m.status.View().Content).To(ContainSubstring("✔ complete"))
+	})
+
+	It("hides complete message on CompleteMsg without a prior CensusMsg (percent < 100)", func() {
+		// When totalFiles + totalDirs is zero, no TotalMsg is
+		// sent. HasTotal stays false and recomputePercent is a
+		// no-op during navigation. The progress bar stays hidden
+		// (no total to compute from). The "✔ complete" message
+		// is hidden too because percent is 0 (< 100).
+		m := baseModel(1)
+		m, _ = update(m, tea.WindowSizeMsg{Width: 120})
+
+		// Dispatch a motif without any CensusMsg.
+		m, _ = update(m, contract.MotifMsg{
+			Path: "/r/f.txt", IsDir: false,
+		})
+		Expect(m.status.HasTotal()).To(BeFalse())
+		Expect(m.status.Percent()).To(Equal(0),
+			"percent stays 0 without a total")
+
+		// CompleteMsg marks done; the bar stays at 0% (no total)
+		// and "✔ complete" does NOT appear because percent < 100.
+		m, cmd := update(m, contract.CompleteMsg{
+			Files: 1, Dirs: 0, Elapsed: 1 * time.Second,
+		})
+		_ = cmd
+		Expect(m.Done).To(BeTrue())
+		Expect(m.status.IsDone()).To(BeTrue())
+		Expect(m.status.Percent()).To(Equal(0),
+			"without a total the bar cannot compute a ratio")
+		Expect(m.status.View().Content).NotTo(ContainSubstring("%"))
+		Expect(m.status.View().Content).NotTo(ContainSubstring("✔"),
+			"complete message hidden when percent < 100")
+	})
+
+	It("does not push fake PercentMsg after CensusMsg has been received", func() {
+		// Regression: the tick handler must NOT push the
+		// time-derived PercentMsg when the status widget already
+		// has a total (meaning CensusMsg was processed). Doing
+		// so would overwrite the real done/total ratio.
+		m := baseModel(1)
+		m, _ = update(m, tea.WindowSizeMsg{Width: 120})
+
+		// Send CensusMsg so HasTotal becomes true.
+		m, _ = update(m, contract.CensusMsg{TotalFiles: 10, TotalDirs: 2})
+		Expect(m.status.HasTotal()).To(BeTrue())
+		Expect(m.status.Percent()).To(Equal(0))
+
+		// Advance one tick. If the tick pushed PercentMsg, the
+		// percent would be non-zero (time-derived). Since it does
+		// not, percent stays at the last recompute value (0).
+		m, _ = update(m, tickMsg(core.Now()))
+		Expect(m.status.Percent()).To(Equal(0),
+			"tick must not overwrite percent when hasTotal is true")
+
+		// Push a motif; the ratio now drives the percent.
+		m, _ = update(m, contract.MotifMsg{
+			Path: "/r/f.txt", IsDir: false,
+		})
+		Expect(m.status.Percent()).To(BeNumerically(">", 0),
+			"percent after motif must be driven by done/total, not time")
+	})
+
+	It("ignores late MotifMsg after CompleteMsg so progress stays at its final ratio", func() {
+		// Regression: the worker pool may dispatch a MotifMsg
+		// after the traversal has completed (race between the
+		// last worker's message and CompleteMsg). The highway
+		// model must NOT forward IncDoneMsg to the status widget
+		// when m.Done is already true, because the IncDoneMsg
+		// would recompute percent from done/total and overwrite
+		// the final value that DoneMsg set via recomputePercent.
+		m := baseModel(1)
+		m, _ = update(m, tea.WindowSizeMsg{Width: 120})
+
+		// Seed total: 10 files + 2 dirs = 12 items.
+		m, _ = update(m, contract.CensusMsg{TotalFiles: 10, TotalDirs: 2})
+		Expect(m.status.Total()).To(Equal(12))
+
+		// Visit all 12 items → 100%.
+		for i := range 12 {
+			m, _ = update(m, contract.MotifMsg{
+				Path: fmt.Sprintf("/r/f%d.txt", i), IsDir: false,
+			})
+		}
+		Expect(m.status.Done()).To(Equal(12))
+		Expect(m.status.Percent()).To(Equal(100))
+		Expect(m.Done).To(BeFalse())
+
+		// CompleteMsg arrives → bar shows natural done/total
+		// (100%, because Done is set to Files+Dirs=12/12).
+		m, cmd := update(m, contract.CompleteMsg{
+			Files: 10, Dirs: 2, Elapsed: 3 * time.Second,
+		})
+		_ = cmd
+		Expect(m.Done).To(BeTrue())
+		Expect(m.status.Percent()).To(Equal(100),
+			"bar reflects natural done/total (12/12 = 100%)")
+		Expect(m.status.IsDone()).To(BeTrue())
+		Expect(m.status.View().Content).To(ContainSubstring("✔ complete"))
+
+		// Late MotifMsg arrives. The track child still processes
+		// it (for lane animation) but the status widget must NOT
+		// see an IncDoneMsg.
+		doneBefore := m.status.Done()
+		_, cmd = update(m, contract.MotifMsg{
+			Path: "/r/late.txt", IsDir: false,
+		})
+		Expect(cmd).To(BeNil(),
+			"late MotifMsg after Done must not produce a spring cmd")
+		Expect(m.status.Done()).To(Equal(doneBefore),
+			"late MotifMsg must not increment done")
+		Expect(m.status.Percent()).To(Equal(100),
+			"late MotifMsg must not overwrite the final ratio")
+		Expect(m.status.IsDone()).To(BeTrue())
 	})
 })
 

--- a/src/prism/views/porthole/model.go
+++ b/src/prism/views/porthole/model.go
@@ -303,7 +303,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		var cmd tea.Cmd
 		m.status, cmd = m.dispatchStatus(status.DoneMsg{
-			Done: msg.Files, IsDone: true, Err: m.ErrMsg,
+			Done: msg.Files + msg.Dirs, IsDone: true, Err: m.ErrMsg,
 		})
 		if cmd != nil {
 			return &m, tea.Batch(cmd)

--- a/src/prism/views/porthole/model_test.go
+++ b/src/prism/views/porthole/model_test.go
@@ -145,21 +145,23 @@ var _ = Describe("Porthole Model", Ordered, func() {
 				"FrameMsg must reach the spring and produce a next-frame cmd")
 		})
 
-		It("reaches 100% on CompleteMsg regardless of CensusMsg total", func() {
+		It("shows completion message with bar at natural done/total ratio", func() {
 			m := baseModel()
 			m = applyOverture(m)
 
+			// Preview total (100) overcounts actual (85).
 			m, _ = update(m, contract.CensusMsg{TotalFiles: 100})
-
 			m, cmd := update(m, contract.CompleteMsg{Files: 80, Dirs: 5, Elapsed: 2 * time.Second})
 			_ = cmd
 
 			Expect(m.status.IsDone()).To(BeTrue())
-			Expect(m.status.Percent()).To(Equal(100))
+			// Done = Files + Dirs = 85, total = 100 → 85%.
+			Expect(m.status.Percent()).To(Equal(85))
 			Expect(m.status.Files()).To(Equal(80))
 			Expect(m.status.Dirs()).To(Equal(5))
-			Expect(m.status.View().Content).To(ContainSubstring("100%"))
-			Expect(m.status.View().Content).To(ContainSubstring("✔ complete"))
+			Expect(m.status.View().Content).To(ContainSubstring("85%"))
+			Expect(m.status.View().Content).NotTo(ContainSubstring("✔"),
+				"complete message hidden when percent < 100")
 		})
 	})
 })

--- a/src/prism/widgets/status/status_test.go
+++ b/src/prism/widgets/status/status_test.go
@@ -375,22 +375,55 @@ var _ = Describe("Model.Update - DoneMsg", func() {
 		Expect(updated.View().Content).To(ContainSubstring("❌ Failed: boom"))
 	})
 
-	It("renders ✔ complete when done with no error", func() {
+	It("renders ✔ complete when done matches total and no error", func() {
 		m := status.New(status.WithStyles(baseStyles()), status.WithFields(status.FieldSelectors{
-			ShowComplete: true,
+			ShowComplete: true, ShowProgress: true,
 		}))
-		updated, _ := update(m, status.DoneMsg{Done: 10, IsDone: true})
+		// "✔ complete" requires both isDone AND percent >= 100,
+		// so seed a total and match done to it.
+		updated, _ := update(m, status.TotalMsg{Total: 10})
+		updated, _ = update(updated, status.IncDoneMsg{N: 10})
+		updated, _ = update(updated, status.DoneMsg{Done: 10, IsDone: true})
 		Expect(updated.View().Content).To(ContainSubstring("✔ complete"))
+		Expect(updated.View().Content).To(ContainSubstring("100%"))
 	})
 
-	It("sets percent to 100 on IsDone=true regardless of done count", func() {
+	It("does NOT force percent to 100 on IsDone=true; bar and complete message are decoupled", func() {
+		// Regression: DoneMsg{IsDone:true} used to set
+		// percent=100 unconditionally, coupling the progress bar
+		// to the "✔ complete" message. The bar must track the
+		// natural done/total ratio; the "✔ complete" message
+		// renders only when BOTH isDone AND percent >= 100.
 		m := status.New(status.WithStyles(baseStyles()), status.WithFields(status.FieldSelectors{
 			ShowProgress: true, ShowComplete: true,
 		}))
+
+		// Without a TotalMsg, hasTotal is false and recomputePercent
+		// is a no-op, so percent stays 0. The "✔ complete" message
+		// does NOT show because percent < 100.
 		updated, _ := update(m, status.DoneMsg{Done: 7, IsDone: true})
-		Expect(updated.Percent()).To(Equal(100))
-		Expect(updated.View().Content).To(ContainSubstring("100%"))
-		Expect(updated.View().Content).To(ContainSubstring("✔ complete"))
+		Expect(updated.IsDone()).To(BeTrue())
+		Expect(updated.Percent()).To(Equal(0),
+			"percent depends on done/total, not on isDone")
+		Expect(updated.View().Content).NotTo(ContainSubstring("✔"),
+			"complete message hidden when percent < 100")
+		Expect(updated.View().Content).NotTo(ContainSubstring("%"),
+			"progress segment is hidden at 0% without a total")
+
+		// With TotalMsg and done == total, percent reaches 100%.
+		m2 := status.New(status.WithStyles(baseStyles()), status.WithFields(status.FieldSelectors{
+			ShowProgress: true, ShowComplete: true,
+		}))
+		m2, _ = update(m2, status.TotalMsg{Total: 10})
+		m2, _ = update(m2, status.IncDoneMsg{N: 10})
+		Expect(m2.Percent()).To(Equal(100))
+
+		m2, _ = update(m2, status.DoneMsg{Done: 10, IsDone: true})
+		Expect(m2.IsDone()).To(BeTrue())
+		Expect(m2.Percent()).To(Equal(100),
+			"10/10 done/total produces 100% naturally")
+		Expect(m2.View().Content).To(ContainSubstring("100%"))
+		Expect(m2.View().Content).To(ContainSubstring("✔ complete"))
 	})
 
 	It("does NOT set percent to 100 on IsDone=false", func() {
@@ -405,6 +438,41 @@ var _ = Describe("Model.Update - DoneMsg", func() {
 		Expect(updated.IsDone()).To(BeFalse())
 		Expect(updated.Percent()).To(Equal(0))
 		Expect(updated.View().Content).NotTo(ContainSubstring("100%"))
+	})
+
+	It("ignores late IncDoneMsg after DoneMsg{IsDone:true} to preserve the final ratio", func() {
+		// Regression: a MotifMsg that arrives after CompleteMsg
+		// dispatches IncDoneMsg, which increments done and
+		// recomputes percent from the done/total ratio. The
+		// widget must reject IncDoneMsg once isDone is true so
+		// the final ratio set by DoneMsg is preserved.
+		m := status.New(status.WithStyles(baseStyles()), status.WithFields(status.FieldSelectors{
+			ShowProgress: true, ShowComplete: true,
+		}))
+
+		// Seed a total and drive done to match (100%).
+		m, _ = update(m, status.TotalMsg{Total: 10})
+		for range 10 {
+			m, _ = update(m, status.IncDoneMsg{N: 1})
+		}
+		Expect(m.Percent()).To(Equal(100))
+
+		// DoneMsg recomputes from done/total (10/10 = 100%).
+		m, _ = update(m, status.DoneMsg{Done: 10, IsDone: true})
+		Expect(m.IsDone()).To(BeTrue())
+		Expect(m.Percent()).To(Equal(100),
+			"percent comes from done/total (10/10 = 100%)")
+		Expect(m.View().Content).To(ContainSubstring("100%"))
+
+		// Late IncDoneMsg arrives. It must NOT change the ratio.
+		m, cmd := update(m, status.IncDoneMsg{N: 1})
+		Expect(cmd).To(BeNil(),
+			"IncDoneMsg after isDone must return nil cmd")
+		Expect(m.IsDone()).To(BeTrue())
+		Expect(m.Percent()).To(Equal(100),
+			"IncDoneMsg after DoneMsg must not overwrite the final ratio")
+		Expect(m.View().Content).To(ContainSubstring("100%"))
+		Expect(m.View().Content).To(ContainSubstring("✔ complete"))
 	})
 })
 
@@ -425,9 +493,9 @@ var _ = Describe("Model.Update - ResetMsg", func() {
 
 		updated, _ = update(updated, status.DoneMsg{Done: 50, IsDone: true})
 		Expect(updated.IsDone()).To(BeTrue())
-		// IsDone=true sets percent to 100 unconditionally.
-		Expect(updated.Percent()).To(Equal(100))
-		Expect(updated.View().Content).To(ContainSubstring("100%"))
+		// DoneMsg recomputes from done/total: 50/100 = 50%.
+		Expect(updated.Percent()).To(Equal(50))
+		Expect(updated.View().Content).To(ContainSubstring("50%"))
 
 		reset, _ := update(updated, status.ResetMsg{})
 		Expect(reset.IsDone()).To(BeFalse())
@@ -486,11 +554,16 @@ var _ = Describe("Model.View - bar visibility", func() {
 		Expect(updated.View().Content).To(ContainSubstring("30%"))
 	})
 
-	It("appears at 100% on DoneMsg{IsDone:true}", func() {
+	It("appears at 100% on DoneMsg{IsDone:true} only when done equals total", func() {
 		m := status.New(status.WithStyles(baseStyles()), status.WithFields(status.FieldSelectors{
 			ShowProgress: true, ShowComplete: true,
 		}))
-		updated, _ := update(m, status.DoneMsg{Done: 10, IsDone: true})
+		// Seed a total and drive done to equal it.
+		updated, _ := update(m, status.TotalMsg{Total: 10})
+		updated, _ = update(updated, status.IncDoneMsg{N: 10})
+		Expect(updated.Percent()).To(Equal(100))
+
+		updated, _ = update(updated, status.DoneMsg{Done: 10, IsDone: true})
 		Expect(updated.Percent()).To(Equal(100))
 		Expect(updated.View().Content).To(ContainSubstring("100%"))
 		Expect(updated.View().Content).To(ContainSubstring("✔ complete"))
@@ -558,13 +631,18 @@ var _ = Describe("Model.Update - spring re-targeting", func() {
 		Expect(updated.Inner().Percent()).To(BeNumerically("~", 0.1, 1e-9))
 	})
 
-	It("DoneMsg{IsDone:true} re-targets to 1.0 and returns a non-nil cmd", func() {
+	It("DoneMsg{IsDone:true} re-targets to the done/total ratio", func() {
 		m := status.New(status.WithStyles(baseStyles()), status.WithFields(status.FieldSelectors{
 			ShowProgress: true, ShowComplete: true,
 		}))
-		updated, cmd := update(m, status.DoneMsg{Done: 7, IsDone: true})
+		// Seed a total and some done so the ratio is non-zero.
+		updated, _ := update(m, status.TotalMsg{Total: 10})
+		updated, _ = update(updated, status.IncDoneMsg{N: 5})
+		Expect(updated.Percent()).To(Equal(50))
+		// DoneMsg recomputes from done/total, not from IsDone.
+		updated, cmd := update(updated, status.DoneMsg{Done: 7, IsDone: true})
 		Expect(cmd).NotTo(BeNil())
-		Expect(updated.Inner().Percent()).To(BeNumerically("~", 1.0, 1e-9))
+		Expect(updated.Inner().Percent()).To(BeNumerically("~", 0.7, 1e-9))
 	})
 
 	It("ResetMsg re-targets to 0.0 and returns a non-nil cmd", func() {

--- a/src/prism/widgets/status/update.go
+++ b/src/prism/widgets/status/update.go
@@ -24,8 +24,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case CountsMsg:
-		m.files, m.dirs, m.errors, m.skipped =
-			msg.Files, msg.Dirs, msg.Errors, msg.Skipped
+		// CountsMsg arrives from two sources that can disagree:
+		//   • MotifMsg handler — track.Dirs() counts ALL unique
+		//     dir MotifMsgs (including skip events)
+		//   • CompleteMsg handler — msg.Dirs from the traversal
+		//     result's DirsVisited, which only counts handler
+		//     invocations (skips excluded)
+		// Using max() prevents the displayed count from dropping
+		// when CompleteMsg overwrites with a lower value.
+		m.files = max(m.files, msg.Files)
+		m.dirs = max(m.dirs, msg.Dirs)
+		m.errors = msg.Errors
+		m.skipped = msg.Skipped
 		return m, nil
 
 	case ElapsedMsg:
@@ -49,20 +59,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Err != "" {
 			m.errMsg = msg.Err
 		}
-		// At completion the percent is known exactly: 100,
-		// overriding any recompute-derived value (which may be
-		// < 100 if real navigation is still in progress when
-		// DoneMsg arrives, or > 100 if the CensusMsg preview
-		// undercounted the true file count).
-		if msg.IsDone {
-			m.percent = 100
-		} else {
-			m = m.recomputePercent()
-		}
+		// The isDone flag gates the "✔ complete" message, but
+		// the message itself only renders when percent >= 100
+		// (error path aside). This lets the bar fill up during
+		// navigation; "✔ complete" appears only when the last
+		// worker actually stops AND progress has reached 100%.
+		m = m.recomputePercent()
 		cmd := m.inner.SetPercent(float64(m.percent) / 100.0)
 		return m, cmd
 
 	case IncDoneMsg:
+		if m.isDone {
+			// Already completed — a late IncDoneMsg must not
+			// overwrite the 100% that DoneMsg set. This can
+			// happen when a worker dispatches a MotifMsg after
+			// the traversal has already completed (race between
+			// the last worker's message and CompleteMsg).
+			return m, nil
+		}
 		n := msg.N
 		if n == 0 {
 			n = 1
@@ -97,11 +111,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // Returns 0 if no total has been set (TotalMsg not yet seen) so
 // the caller does not have to guard. The result is clamped to
 // 100 because the CensusMsg-supplied total is a preview
-// estimate: if real navigation visits more files than previewed,
-// done > total and the raw ratio would exceed 100. DoneMsg with
-// IsDone=true sets percent to 100 unconditionally on top of
-// whatever recompute produces, so "100% reached" at completion
-// is preserved as a stable signal.
+// estimate: if real navigation visits more items than previewed,
+// done > total and the raw ratio would exceed 100.
+//
+// DoneMsg with IsDone=true does NOT force percent to 100; the
+// "✔ complete" message and the progress bar are independent.
+// The bar tracks the done/total ratio throughout, so it can
+// reach 100% naturally when done == total during navigation.
 //
 // TODO(progress-indicator-design): consider switching the label
 // to a count display ("X / Y") during navigation so the

--- a/src/prism/widgets/status/view.go
+++ b/src/prism/widgets/status/view.go
@@ -110,13 +110,23 @@ func (m Model) View() tea.View {
 				label += fmt.Sprintf(" (+%d more)", m.errors-1)
 			}
 			msg = " " + m.styles.ErrorStyle.Render(label) + " "
-		} else {
+		} else if m.hasTotal && m.percent >= 100 {
+			// "✔ complete" appears only when ALL of:
+			//   1. the last worker has finished (isDone),
+			//   2. a real total was provided (hasTotal), and
+			//   3. the progress bar has reached 100% (done >= total).
+			// Without a real total, PercentMsg drives the bar from
+			// elapsed time and can reach 100% before navigation is
+			// actually complete. Requiring hasTotal prevents the
+			// message from appearing with fake progress data.
 			msg = " " + m.styles.ProgressStyle.Render("✔ complete") + " "
 		}
-		segments = append(segments, segment{
-			content:   msg,
-			separator: true,
-		})
+		if msg != "" {
+			segments = append(segments, segment{
+				content:   msg,
+				separator: true,
+			})
+		}
 	}
 
 	// Elapsed segment (always last, right-aligned)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed premature completion notifications by explicitly draining background workers before signaling completion.
  * Progress now accurately reflects both files and directories processed.
  * Completion checkmark displays only when progress reaches 100% with a valid total count, preventing false "complete" indicators.
  * Improved resilience to out-of-order or delayed progress messages.

* **Tests**
  * Expanded test coverage for progress calculation and completion semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->